### PR TITLE
Pre-program registration bug fix, direct URL and badge detail improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- Link from badges to search events which can earn them
 - Add QueryString capabilities to events index
   - `/Events/?Branch=<branch name>` shows events for that branch
   - `/Events/?System=<system name>` shows events for that library system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Add QueryString capabilities to events index
+  - `/Events/?Branch=<branch name>` shows events for that branch
+  - `/Events/?System=<system name>` shows events for that library system
+  - `/Events?Search=<search string>` shows events with the provided search string
+  - `/Challenges?Search=<search string>` shows challenges with the provided search string
+
 ## [3.1.0] - 2016-04-27
 ### Added
 - Feature for optionally requiring users to enter book details

--- a/GRA.Logic/Badge.cs
+++ b/GRA.Logic/Badge.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace GRA.Logic
+{
+    public class Badge
+    {
+        private const string NoBadgePath = "~/images/Badges/no_badge.png";
+
+        public BadgeDisplayDetails GetForDisplay(HttpServerUtility server,
+            int badgeId,
+            int patronId)
+        {
+            var badge = SRP.DAL.Badge.FetchObject(badgeId);
+            if (badge == null)
+            {
+                throw new Exception("Badge not found.");
+            }
+            var badgeDetails = new BadgeDisplayDetails();
+
+            badgeDetails.BadgeId = badge.BID;
+            badgeDetails.DisplayName = badge.UserName;
+            badgeDetails.Hidden = badge.HiddenFromPublic == true;
+
+            // if the badge is flagged as hidden from the public, ensure the user has earned it
+            if (patronId > 0)
+            {
+                var patronBadges = SRP.DAL.PatronBadges.GetAll(patronId);
+                if (patronBadges != null && patronBadges.Tables.Count > 0)
+                {
+                    var filterExpression = string.Format("BadgeID = {0}", badge.BID);
+                    var patronHasBadge = patronBadges.Tables[0].Select(filterExpression);
+                    if (patronHasBadge.Count() > 0)
+                    {
+                        badgeDetails.Earned = true;
+                        var earned = patronHasBadge[0]["DateEarned"] as DateTime?;
+                        if (earned != null)
+                        {
+                            badgeDetails.DateEarned = ((DateTime)earned).ToShortDateString();
+                        }
+                    }
+                }
+            }
+
+            string badgePath = NoBadgePath;
+            string potentialBadgePath = string.Format("~/Images/Badges/{0}.png",
+                                                      badgeId);
+            if (System.IO.File.Exists(server.MapPath(potentialBadgePath)))
+            {
+                badgePath = potentialBadgePath;
+            }
+            badgeDetails.ImageUrl = badgePath;
+            badgeDetails.AlternateText = string.Format("Badge: {0}", badge.UserName);
+
+            var earn = new HashSet<string>();
+
+            string earnText = SRP.DAL.Badge.GetBadgeReading(badgeId);
+            if (earnText.Length > 0)
+            {
+                earn.Add(string.Format("Earn points by reading: {0}.", earnText));
+            }
+
+            earnText = SRP.DAL.Badge.GetBadgeGoal(badgeId);
+            if (earnText.Length > 0)
+            {
+                earn.Add(string.Format("Achieve part of your personal reading goal: {0}.",
+                    earnText));
+            }
+
+            earnText = SRP.DAL.Badge.GetEnrollmentPrograms(badgeId);
+            if (earnText.Length > 0)
+            {
+                earn.Add(string.Format("Enroll in a reading program: {0}.", earnText));
+            }
+
+            earnText = SRP.DAL.Badge.GetBadgeBookLists(badgeId);
+            if (earnText.Length > 0)
+            {
+                earn.Add(string.Format("Complete a Challenge: {0}.", earnText));
+            }
+
+            earnText = SRP.DAL.Badge.GetBadgeGames(badgeId);
+            if (earnText.Length > 0)
+            {
+                earn.Add(string.Format("Unlock and complete an Adventure: {0}.", earnText));
+            }
+
+            earnText = SRP.DAL.Badge.GetBadgeEvents(badgeId);
+            if (earnText.Length > 0)
+            {
+                earn.Add(string.Format("Attend an Event: {0}.",
+                    CreateSearchLinks(server, earnText, "~/Events/?Search={0}")));
+            }
+
+            if (earn.Count == 0)
+            {
+                earn.Add("Learn the secret code to unlock it.");
+            }
+
+            badgeDetails.HowToEarn = earn.OrderBy(x => x).ToArray();
+
+            return badgeDetails;
+        }
+
+        private string CreateSearchLinks(HttpServerUtility server,
+            string stringCsvList,
+            string urlFormat)
+        {
+            string[] items;
+            if (stringCsvList.Contains(','))
+            {
+                items = stringCsvList.Split(',');
+            }
+            else
+            {
+                items = new string[1] { stringCsvList };
+            }
+
+            StringBuilder stringWithLinks = null;
+            foreach (string stringItem in items)
+            {
+                string link = string.Format(urlFormat, server.UrlEncode(stringItem.Trim()));
+                if (stringWithLinks != null)
+                {
+                    stringWithLinks.Append(", ");
+                }
+                else
+                {
+                    stringWithLinks = new StringBuilder();
+                }
+                stringWithLinks.AppendFormat("<a href=\"{0}\">{1}</a>",
+                   VirtualPathUtility.ToAbsolute(link),
+                   stringItem.Trim());
+            }
+            return stringWithLinks.ToString();
+        }
+    }
+}

--- a/GRA.Logic/Badge.cs
+++ b/GRA.Logic/Badge.cs
@@ -131,7 +131,7 @@ namespace GRA.Logic
                 {
                     stringWithLinks = new StringBuilder();
                 }
-                stringWithLinks.AppendFormat("<a href=\"{0}\">{1}</a>",
+                stringWithLinks.AppendFormat("<a href=\"{0}\" target=\"_blank\">{1} <small><span class=\"glyphicon glyphicon-new-window\"></span></small></a>",
                    VirtualPathUtility.ToAbsolute(link),
                    stringItem.Trim());
             }

--- a/GRA.Logic/BadgeDisplayDetails.cs
+++ b/GRA.Logic/BadgeDisplayDetails.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace GRA.Logic
+{
+    public class BadgeDisplayDetails
+    {
+        public int BadgeId { get; set; }
+        public string DisplayName { get; set; }
+        public string ImageUrl { get; set; }
+        public string AlternateText { get; set; }
+        public string[] HowToEarn { get; set; }
+        public string DateEarned { get; set; }
+        public bool Hidden { get; set; }
+        public bool Earned { get; set; }
+    }
+}

--- a/GRA.Logic/GRA.Logic.csproj
+++ b/GRA.Logic/GRA.Logic.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Code.cs" />
     <Compile Include="Game.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueryString.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SRPUtilities\SRPUtilities.csproj">

--- a/GRA.Logic/GRA.Logic.csproj
+++ b/GRA.Logic/GRA.Logic.csproj
@@ -40,6 +40,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Badge.cs" />
+    <Compile Include="BadgeDisplayDetails.cs" />
     <Compile Include="Banner.cs" />
     <Compile Include="Code.cs" />
     <Compile Include="Game.cs" />

--- a/GRA.Logic/QueryString.cs
+++ b/GRA.Logic/QueryString.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace GRA.Logic
+{
+   
+    public class QueryString
+    {
+        public string GetSystemIdString(string system)
+        {
+            if (string.IsNullOrWhiteSpace(system))
+            {
+                return null;
+            }
+            var systemCodes = SRP.DAL.Codes.GetAll();
+            if (systemCodes != null
+                && systemCodes.Tables != null
+                && systemCodes.Tables.Count > 0)
+            {
+                // code type id = 2 means library district/system
+                string query = string.Format(
+                    "CTID = 2 AND Code = '{0}'",
+                    system.Trim().Replace("'", "''"));
+                var rows = systemCodes.Tables[0].Select(query);
+                if (rows.Count() > 0)
+                {
+                    return rows[0]["CID"].ToString();
+                }
+            }
+            return null;
+        }
+
+        public Tuple<string,string> GetSystemBranchIdStrings(string branch)
+        {
+            if(string.IsNullOrWhiteSpace(branch))
+            {
+                return null;
+            }
+            string systemIdString = null;
+            string branchIdString = null;
+            var branchCodes = SRP.DAL.Codes.GetAll();
+            if (branchCodes != null
+                && branchCodes.Tables != null
+                && branchCodes.Tables.Count > 0)
+            {
+                // code type id = 1 means library branch
+                string query = string.Format(
+                    "CTID = 1 AND Code = '{0}'",
+                    branch.Trim().Replace("'", "''"));
+                var rows = branchCodes.Tables[0].Select(query);
+                if (rows.Count() > 0)
+                {
+                    branchIdString = rows[0]["CID"].ToString();
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(branchIdString))
+            {
+                int branchId = -1;
+                if (int.TryParse(branchIdString, out branchId) && branchId != -1)
+                {
+                    var branchObject = SRP.DAL.LibraryCrosswalk.FetchObjectByLibraryID(branchId);
+                    if (branchObject != null)
+                    {
+                        systemIdString = branchObject.DistrictID.ToString();
+                    }
+                }
+            }
+            return new Tuple<string, string>(systemIdString, branchIdString);
+        }
+    }
+}

--- a/Great Reading Adventure.sln
+++ b/Great Reading Adventure.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SRP", "SRP\SRP.csproj", "{E0C4AC89-4F15-44A4-8B88-9D4A7FDC1BF9}"
 EndProject
@@ -11,6 +11,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SRP_DAL", "SRP_DAL\SRP_DAL.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B04466CA-2F04-4D6F-9940-2EA318354274}"
 	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
 		docs\conf.py = docs\conf.py
 		CreateDatabase.sql = CreateDatabase.sql
 		CREDITS.md = CREDITS.md

--- a/SRP/Controls/ChallengesCtl.ascx.cs
+++ b/SRP/Controls/ChallengesCtl.ascx.cs
@@ -94,7 +94,7 @@ namespace GRA.SRP.Controls
             }
             else
             {
-                if(amount > total)
+                if (amount > total)
                 {
                     return 100;
                 }
@@ -133,6 +133,21 @@ namespace GRA.SRP.Controls
         {
             if (!IsPostBack)
             {
+                if (Request.QueryString.Count > 0)
+                {
+                    var querySearch = Request.QueryString["Search"];
+                    if (!string.IsNullOrWhiteSpace(querySearch))
+                    {
+                        if (querySearch.Length > 255)
+                        {
+                            SearchText.Text = querySearch.Substring(0, 255);
+                        }
+                        else
+                        {
+                            SearchText.Text = querySearch;
+                        }
+                    }
+                }
                 PopulateChallengeList();
                 this.ShowModal = false;
             }

--- a/SRP/Controls/Events.ascx
+++ b/SRP/Controls/Events.ascx
@@ -65,6 +65,7 @@
             <label for="<%=SearchText.ClientID %>">Search:</label>
             <asp:TextBox
                 ID="SearchText"
+                MaxLength="255"
                 runat="server"
                 placeholder="Enter text here to search events, try a word or phrase"
                 CssClass="form-control"></asp:TextBox>

--- a/SRP/Controls/Events.ascx.cs
+++ b/SRP/Controls/Events.ascx.cs
@@ -19,6 +19,10 @@ namespace GRA.SRP.Controls
         public string LastAvailableDate { get; set; }
         public string NoneAvailableText { get; set; }
         public bool Filtered { get; set; }
+        public string SelectLibrary { get; set; }
+        public string SelectSystem { get; set; }
+        public bool InitialFilter { get; set; }
+
         protected string DisplayEventDateTime(DateTime? eventDate)
         {
             if (eventDate != null)
@@ -38,7 +42,20 @@ namespace GRA.SRP.Controls
         {
             if (!IsPostBack)
             {
-                DoFilter();
+                InitialFilter = false;
+                if (Request.QueryString.Count > 0)
+                {
+                    InitialFilter = PrepareFilter();
+                    Page.PreRenderComplete += (s, args) =>
+                    {
+                        EnactFilter();
+                    };
+                }
+
+                if (!InitialFilter)
+                {
+                    DoFilter();
+                }
             }
 
             int programId;
@@ -56,6 +73,94 @@ namespace GRA.SRP.Controls
 
             var basePage = (BaseSRPPage)Page;
             this.NoneAvailableText = basePage.GetResourceString("events-none-available");
+        }
+
+        protected void EnactFilter()
+        {
+            if(!IsPostBack && InitialFilter)
+            {
+                if(!string.IsNullOrWhiteSpace(SelectLibrary))
+                {
+                    var branchItem = BranchId.Items.FindByValue(SelectLibrary);
+                    if(branchItem != null)
+                    {
+                        BranchId.SelectedValue = SelectLibrary;
+                    }
+                }
+                if(!string.IsNullOrWhiteSpace(SelectSystem))
+                {
+                    var systemItem = SystemId.Items.FindByValue(SelectSystem);
+                    if(systemItem != null)
+                    {
+                        SystemId.SelectedValue = SelectSystem;
+                    }
+                }
+                DoFilter();
+            }
+        }
+
+        protected bool PrepareFilter()
+        {
+            bool filter = false;
+            var querySystem = Request.QueryString["System"];
+            if (!string.IsNullOrWhiteSpace(querySystem))
+            {
+                int systemId = -1;
+                if (int.TryParse(querySystem, out systemId) && systemId != -1)
+                {
+                    var branch = DAL.Codes.GetAllLibrarySystems();
+                    if (branch != null 
+                        && branch.Tables != null 
+                        && branch.Tables.Count > 0
+                        && branch.Tables[0].Columns.Contains("LibSys"))
+                    {
+                        var rows = branch.Tables[0].Select(string.Format("LibSys = {0}", systemId));
+                        if (rows.Count() > 0)
+                        {
+                            SelectSystem = rows[0]["LibSys"].ToString();
+                            if (!string.IsNullOrWhiteSpace(SelectSystem))
+                            {
+                                filter = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(SelectSystem))
+            {
+                var queryBranch = Request.QueryString["Branch"];
+                if (!string.IsNullOrWhiteSpace(queryBranch))
+                {
+                    int branchId = -1;
+                    if (int.TryParse(queryBranch, out branchId) && branchId != -1)
+                    {
+
+                        var branch = DAL.LibraryCrosswalk.FetchObjectByLibraryID(branchId);
+                        if (branch != null)
+                        {
+                            SelectLibrary = branch.BranchID.ToString();
+                            SelectSystem = branch.DistrictID.ToString();
+                            filter = true;
+                        }
+                    }
+                }
+            }
+
+            var querySearch = Request.QueryString["Search"];
+            if (!string.IsNullOrWhiteSpace(querySearch))
+            {
+                filter = true;
+                if (querySearch.Length > 255)
+                {
+                    SearchText.Text = querySearch.Substring(0, 255);
+                }
+                else
+                {
+                    SearchText.Text = querySearch;
+                }
+            }
+            return filter;
         }
 
         protected void DoFilter()

--- a/SRP/Controls/Events.ascx.cs
+++ b/SRP/Controls/Events.ascx.cs
@@ -77,20 +77,20 @@ namespace GRA.SRP.Controls
 
         protected void EnactFilter()
         {
-            if(!IsPostBack && InitialFilter)
+            if (!IsPostBack && InitialFilter)
             {
-                if(!string.IsNullOrWhiteSpace(SelectLibrary))
+                if (!string.IsNullOrWhiteSpace(SelectLibrary))
                 {
                     var branchItem = BranchId.Items.FindByValue(SelectLibrary);
-                    if(branchItem != null)
+                    if (branchItem != null)
                     {
                         BranchId.SelectedValue = SelectLibrary;
                     }
                 }
-                if(!string.IsNullOrWhiteSpace(SelectSystem))
+                if (!string.IsNullOrWhiteSpace(SelectSystem))
                 {
                     var systemItem = SystemId.Items.FindByValue(SelectSystem);
-                    if(systemItem != null)
+                    if (systemItem != null)
                     {
                         SystemId.SelectedValue = SelectSystem;
                     }
@@ -102,28 +102,14 @@ namespace GRA.SRP.Controls
         protected bool PrepareFilter()
         {
             bool filter = false;
+            var qs = new Logic.QueryString();
             var querySystem = Request.QueryString["System"];
             if (!string.IsNullOrWhiteSpace(querySystem))
             {
-                int systemId = -1;
-                if (int.TryParse(querySystem, out systemId) && systemId != -1)
+                SelectSystem = qs.GetSystemIdString(Server.UrlDecode(querySystem));
+                if(!string.IsNullOrEmpty(SelectSystem))
                 {
-                    var branch = DAL.Codes.GetAllLibrarySystems();
-                    if (branch != null 
-                        && branch.Tables != null 
-                        && branch.Tables.Count > 0
-                        && branch.Tables[0].Columns.Contains("LibSys"))
-                    {
-                        var rows = branch.Tables[0].Select(string.Format("LibSys = {0}", systemId));
-                        if (rows.Count() > 0)
-                        {
-                            SelectSystem = rows[0]["LibSys"].ToString();
-                            if (!string.IsNullOrWhiteSpace(SelectSystem))
-                            {
-                                filter = true;
-                            }
-                        }
-                    }
+                    filter = true;
                 }
             }
 
@@ -132,15 +118,14 @@ namespace GRA.SRP.Controls
                 var queryBranch = Request.QueryString["Branch"];
                 if (!string.IsNullOrWhiteSpace(queryBranch))
                 {
-                    int branchId = -1;
-                    if (int.TryParse(queryBranch, out branchId) && branchId != -1)
+                    var sysBranchId = qs.GetSystemBranchIdStrings(queryBranch);
+                    if (sysBranchId != null)
                     {
-
-                        var branch = DAL.LibraryCrosswalk.FetchObjectByLibraryID(branchId);
-                        if (branch != null)
+                        SelectSystem = sysBranchId.Item1;
+                        SelectLibrary = sysBranchId.Item2;
+                        if(!string.IsNullOrEmpty(SelectSystem)
+                           || !string.IsNullOrEmpty(SelectLibrary))
                         {
-                            SelectLibrary = branch.BranchID.ToString();
-                            SelectSystem = branch.DistrictID.ToString();
                             filter = true;
                         }
                     }

--- a/SRP/Controls/PatronRegistration.ascx.cs
+++ b/SRP/Controls/PatronRegistration.ascx.cs
@@ -36,6 +36,42 @@ namespace GRA.SRP.Controls
         {
             if (!IsPostBack)
             {
+                var sessionProgramId = Session["ProgramID"];
+                int programId;
+                if (sessionProgramId != null)
+                {
+                    try
+                    {
+                        programId = sessionProgramId.ToString().SafeToInt();
+                    }
+                    catch (Exception)
+                    {
+                        programId = Programs.GetDefaultProgramID();
+                    }
+                }
+                else
+                {
+                    programId = Programs.GetDefaultProgramID();
+
+                }
+                var currentProgram = Programs.FetchObject(programId);
+
+                DateTime startDate = currentProgram.StartDate < currentProgram.LoggingStart
+                    ? currentProgram.StartDate
+                    : currentProgram.LoggingStart;
+
+                DateTime endDate = currentProgram.EndDate > currentProgram.LoggingEnd
+                    ? currentProgram.EndDate
+                    : currentProgram.LoggingEnd;
+
+                if (DateTime.Now < startDate)
+                {
+                    Response.Redirect("~");
+                }
+                else if (DateTime.Now > endDate)
+                {
+                    Response.Redirect("~");
+                }
                 var dataSource = RegistrationSettings.GetAll();
                 rptr.DataSource = dataSource;
                 rptr.DataBind();
@@ -133,7 +169,8 @@ namespace GRA.SRP.Controls
                     var DOB = DateTime.Parse(sDOB);
                     age = DateTime.Now.Year - DOB.Year;
                 }
-                else {
+                else
+                {
                     int.TryParse(sAge, out age);
                 }
 
@@ -171,7 +208,8 @@ namespace GRA.SRP.Controls
 
                     Step.Text = (curStep + 2).ToString();
                 }
-                else {
+                else
+                {
                     if (age > 17 && SRPSettings.GetSettingValue("AllowFamilyAccounts").SafeToBoolYes())
                     {
                         // Ask about adult
@@ -183,7 +221,8 @@ namespace GRA.SRP.Controls
 
                         Step.Text = (curStep + 1).ToString();
                     }
-                    else {
+                    else
+                    {
                         var curPanel = rptr.Items[0].FindControl("Panel" + curStep.ToString());
                         var newPanel = rptr.Items[0].FindControl("Panel" + (curStep + 2).ToString());
 
@@ -234,7 +273,7 @@ namespace GRA.SRP.Controls
                 }
 
                 var goal = rptr.Items[0].FindControl("Goal") as TextBox;
-                if(goal != null
+                if (goal != null
                    && selectedProgram.GoalDefault > 0)
                 {
                     goal.Text = selectedProgram.GoalDefault.ToString();
@@ -381,7 +420,8 @@ namespace GRA.SRP.Controls
                     btnDone.Visible = true;
                     return;
                 }
-                else {
+                else
+                {
                     // we're done with registration, we can just jump right in
                     TestingBL.CheckPatronNeedsPreTest();
                     TestingBL.CheckPatronNeedsPostTest();
@@ -553,7 +593,8 @@ namespace GRA.SRP.Controls
 
                     Step.Text = (curStep - 2).ToString();
                 }
-                else {
+                else
+                {
                     if (Age > 17)
                     {
                         // Ask about adult
@@ -565,7 +606,8 @@ namespace GRA.SRP.Controls
 
                         Step.Text = (curStep - 1).ToString();
                     }
-                    else {
+                    else
+                    {
                         var curPanel = rptr.Items[0].FindControl("Panel" + curStep.ToString());
                         var newPanel = rptr.Items[0].FindControl("Panel" + (curStep - 2).ToString());
 
@@ -593,7 +635,8 @@ namespace GRA.SRP.Controls
                     var DOB = DateTime.Parse(sDOB);
                     age = DateTime.Now.Year - DOB.Year;
                 }
-                else {
+                else
+                {
                     int.TryParse(sAge, out age);
                 }
 
@@ -699,7 +742,8 @@ namespace GRA.SRP.Controls
                         ? ((DropDownList)(rptr.Items[0]).FindControl("District")).SelectedValue
                         : lc.DistrictID.ToString();
                 }
-                else {
+                else
+                {
                     p.District = ((DropDownList)(rptr.Items[0]).FindControl("District")).SelectedValue;
                 }
                 var sc = SchoolCrosswalk.FetchObjectBySchoolID(p.SchoolName.SafeToInt());
@@ -713,7 +757,8 @@ namespace GRA.SRP.Controls
                         ? FormatHelper.SafeToInt(((DropDownList)(rptr.Items[0]).FindControl("SchoolType")).SelectedValue)
                         : sc.SchTypeID;
                 }
-                else {
+                else
+                {
                     p.SDistrict = ((DropDownList)(rptr.Items[0]).FindControl("SDistrict")).SelectedValue.SafeToInt();
                 }
 
@@ -796,7 +841,8 @@ namespace GRA.SRP.Controls
                         new SessionTools(Session).EstablishPatron(p);
                     }
                 }
-                else {
+                else
+                {
                     StringBuilder message = new StringBuilder("<strong>");
                     message.AppendFormat(SRPResources.ApplicationError1, "<ul>");
                     foreach (BusinessRulesValidationMessage m in p.ErrorCodes)


### PR DESCRIPTION
- Fix #149 Guessing the registration URL allows circumventing the log start date bug
- Add direct-link search for Events (by system, branch, or search string)
- Add direct-link search for Challenges (by search string)
- Unify badge detail logic (was in two places)
- When badge details show an event, add a link to search for that event