### PR TITLE
Fix issue with duplicate initial page loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Disable add default avatars button on click
 - Misspelled app setting (GraApplicationDiscriminator)
 - Handle admin users self-deleting properly (log out, redirect to front of site)
+- Issue with double initial page loads causing duplicate database insertions (#283)
 
 ### Removed
 - Comments from appsettings.json, see the [manual](http://manual.greatreadingadventure.com/en/latest/technical/appsettings/) for more information

--- a/src/GRA.Web/Startup.cs
+++ b/src/GRA.Web/Startup.cs
@@ -349,7 +349,8 @@ namespace GRA.Web
             IHostingEnvironment env,
             ILoggerFactory loggerFactory,
             IPathResolver pathResolver,
-            RoleService roleService)
+            RoleService roleService,
+            SiteLookupService siteLookupService)
         {
             loggerFactory.AddSerilog();
 
@@ -364,6 +365,7 @@ namespace GRA.Web
             }
 
             app.ApplicationServices.GetService<Data.Context>().Migrate();
+            Task.Run(() => siteLookupService.GetDefaultSiteIdAsync()).Wait();
             Task.Run(() => roleService.SyncPermissionsAsync()).Wait();
 
             app.UseResponseCompression();


### PR DESCRIPTION
- Fix #283 Simultaneous initial loads of the site cause multiple
  database records to be inserted