### PR TITLE
Fix throwing exception on missing trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Misspelled app setting (GraApplicationDiscriminator)
 - Handle admin users self-deleting properly (log out, redirect to front of site)
 - Issue with double initial page loads causing duplicate database insertions (#283)
+- Editing a trigger that doesn't exist now shows an error rather than logging an exception
 
 ### Removed
 - Comments from appsettings.json, see the [manual](http://manual.greatreadingadventure.com/en/latest/technical/appsettings/) for more information

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -399,6 +399,12 @@ namespace GRA.Controllers.MissionControl
         public async Task<IActionResult> Edit(int id)
         {
             var trigger = await _triggerService.GetByIdAsync(id);
+
+            if(trigger == null)
+            {
+                ShowAlertWarning($"Could not find trigger id {id}, possibly it has been deleted.");
+                return RedirectToAction("Index");
+            }
             var site = await GetCurrentSiteAsync();
             var siteUrl = await _siteService.GetBaseUrl(Request.Scheme, Request.Host.Value);
             var viewModel = new TriggersDetailViewModel


### PR DESCRIPTION
Trying to edit a trigger that didn't exist threw an exception, now it
just displays an error to the user.