### PR TITLE
Add {Link} token to vendor code mails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Automatically assign any new permissions to the System Administrator role
 - User-friendly page to display page not found (404) errors
 - Ability to send test emails from Mission Control
+- Token {Link} in vendor code mails
 
 ### Changed
 - Updated package dependencies to latest compatible versions

--- a/src/GRA.Domain.Service/VendorCodeService.cs
+++ b/src/GRA.Domain.Service/VendorCodeService.cs
@@ -523,6 +523,10 @@ namespace GRA.Domain.Service
                     // token and url - make token clickable to go to url
                     body = codeType.Mail.Replace(TemplateToken.VendorCodeToken,
                         $"<a href=\"{url}\" _target=\"blank\">{assignedCode}</a>");
+                    if(body.Contains(TemplateToken.VendorLinkToken))
+                    {
+                        body = body.Replace(TemplateToken.VendorLinkToken, url);
+                    }
                 }
             }
 

--- a/src/GRA/TemplateToken.cs
+++ b/src/GRA/TemplateToken.cs
@@ -3,5 +3,6 @@
     public struct TemplateToken
     {
         public const string VendorCodeToken = "{Code}";
+        public const string VendorLinkToken = "{Link}";
     }
 }

--- a/src/GRA/TemplateToken.cs
+++ b/src/GRA/TemplateToken.cs
@@ -2,7 +2,7 @@
 {
     public struct TemplateToken
     {
-        public const string VendorCodeToken = "{Code}";
-        public const string VendorLinkToken = "{Link}";
+        public static readonly string VendorCodeToken = "{Code}";
+        public static readonly string VendorLinkToken = "{Link}";
     }
 }


### PR DESCRIPTION
- Add ability to pass link in addition to code and link in vendor code
  mails