### PR TITLE
Improve site management and startup logging

### DIFF
--- a/src/GRA.Controllers/JoinController.cs
+++ b/src/GRA.Controllers/JoinController.cs
@@ -1061,14 +1061,21 @@ namespace GRA.Controllers
             return View(model);
         }
 
-        public IActionResult AuthorizationCode()
+        public async Task<IActionResult> AuthorizationCode()
         {
             if (TempData.ContainsKey(AuthCodeAttempts) && (int)TempData.Peek(AuthCodeAttempts) >= 5)
             {
-                ShowAlertDanger("Too many failed authorization attemps.");
+                ShowAlertDanger("Too many failed authorization attempts.");
                 return RedirectToAction(nameof(HomeController.Index), nameof(HomeController));
             }
-            return View();
+            var site = await GetCurrentSiteAsync();
+            string siteLogoUrl = site.SiteLogoUrl
+                ?? Url.Content(Defaults.SiteLogoPath);
+
+            return View(new AuthorizationCodeViewModel
+            {
+                SiteLogoUrl = siteLogoUrl
+            });
         }
 
         [HttpPost]
@@ -1104,7 +1111,7 @@ namespace GRA.Controllers
 
             if (TempData.ContainsKey(AuthCodeAttempts) && (int)TempData.Peek(AuthCodeAttempts) >= 5)
             {
-                ShowAlertDanger("Too many failed authorization attemps.");
+                ShowAlertDanger("Too many failed authorization attempts.");
                 return RedirectToAction(nameof(HomeController.Index), nameof(HomeController));
             }
             ShowAlertDanger("Invalid authorization code.");

--- a/src/GRA.Controllers/ViewModel/Join/AuthorizationCodeViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/Join/AuthorizationCodeViewModel.cs
@@ -6,5 +6,6 @@ namespace GRA.Controllers.ViewModel.Join
     {
         [DisplayName("Authorization Code")]
         public string AuthorizationCode { get; set; }
+        public string SiteLogoUrl { get; set; }
     }
 }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Sites/SiteConfigurationViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Sites/SiteConfigurationViewModel.cs
@@ -8,10 +8,10 @@ namespace GRA.Controllers.ViewModel.MissionControl.Sites
     {
         public int Id { get; set; }
 
-        [DisplayName("Site Logo Url")]
-        [MaxLength(100)]
+        [DisplayName("Site Logo URL")]
+        [MaxLength(255)]
         public string SiteLogoUrl { get; set; }
-        [DisplayName("External Event List Url")]
+        [DisplayName("External Event List URL")]
         public string ExternalEventListUrl { get; set; }
         [DisplayName("Max Points Per Challenge Task")]
         public int? MaxPointsPerChallengeTask { get; set; }
@@ -21,7 +21,7 @@ namespace GRA.Controllers.ViewModel.MissionControl.Sites
         public bool SinglePageSignUp { get; set; }
         [DisplayName("Google Analytics Tracking Id")]
         public string GoogleAnalyticsTrackingId { get; set; }
-        [DisplayName("Is Https Forced")]
+        [DisplayName("Is HTTPS Forced")]
         public bool IsHttpsForced { get; set; }
         [DisplayName("From Email Name")]
         public string FromEmailName { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Sites/SiteSocialMediaViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Sites/SiteSocialMediaViewModel.cs
@@ -7,16 +7,16 @@ namespace GRA.Controllers.ViewModel.MissionControl.Sites
     {
         public int Id { get; set; }
 
-        [DisplayName("Facebook App Id")]
+        [DisplayName("Facebook App ID")]
         [MaxLength(100)]
         public string FacebookAppId { get; set; }
-        [DisplayName("Facebook Image Url")]
-        [MaxLength(100)]
+        [DisplayName("Facebook/Open Graph Image URL")]
+        [MaxLength(255)]
         public string FacebookImageUrl { get; set; }
         [DisplayName("Twitter Large Card")]
         public bool? TwitterLargeCard { get; set; }
-        [DisplayName("Twitter Card ImageUrl")]
-        [MaxLength(100)]
+        [DisplayName("Twitter Card Image URL")]
+        [MaxLength(255)]
         public string TwitterCardImageUrl { get; set; }
         [DisplayName("Twitter Username")]
         [MaxLength(15)]
@@ -24,7 +24,7 @@ namespace GRA.Controllers.ViewModel.MissionControl.Sites
         [DisplayName("Twitter Avatar Message")]
         [MaxLength(255)]
         public string TwitterAvatarMessage { get; set; }
-        [DisplayName("Twitter Avatar Hashtags")]
+        [DisplayName("Twitter Avatar Hashtag")]
         [MaxLength(100)]
         public string TwitterAvatarHashtags { get; set; }
         [DisplayName("Avatar Card Description")]

--- a/src/GRA.Data.SQLite/SQLiteContext.cs
+++ b/src/GRA.Data.SQLite/SQLiteContext.cs
@@ -16,7 +16,7 @@ namespace GRA.Data.SQLite
             }
             else
             {
-                optionsBuilder.UseSqlite(config[ConfigurationKey.DefaultCSSQLite]);
+                optionsBuilder.UseSqlite(_config[ConfigurationKey.DefaultCSSQLite]);
             }
         }
     }

--- a/src/GRA.Data.SqlServer/SqlServerContext.cs
+++ b/src/GRA.Data.SqlServer/SqlServerContext.cs
@@ -17,7 +17,7 @@ namespace GRA.Data.SqlServer
             {
                 // .UseRowNumberForPaging is for SQL Server 2008 compatibility:
                 // https://github.com/aspnet/EntityFramework/issues/4616
-                optionsBuilder.UseSqlServer(config[ConfigurationKey.DefaultCSSqlServer],
+                optionsBuilder.UseSqlServer(_config[ConfigurationKey.DefaultCSSqlServer],
                     _ => _.UseRowNumberForPaging());
             }
         }

--- a/src/GRA.Data/Context.cs
+++ b/src/GRA.Data/Context.cs
@@ -11,14 +11,10 @@ namespace GRA.Data
     public abstract class Context : DbContext
     {
         protected readonly string devConnectionString;
-        protected readonly IConfigurationRoot config;
+        protected readonly IConfigurationRoot _config;
         public Context(IConfigurationRoot config)
         {
-            if (config == null)
-            {
-                throw new ArgumentNullException(nameof(config));
-            }
-            this.config = config;
+            _config = config ?? throw new ArgumentNullException(nameof(config));
             devConnectionString = null;
         }
         protected internal Context(string connectionString)
@@ -110,9 +106,19 @@ namespace GRA.Data
             Database.Migrate();
         }
 
+        public IEnumerable<string> GetPendingMigrations()
+        {
+            return Database.GetPendingMigrations();
+        }
+
         public async Task MigrateAsync()
         {
             await Database.MigrateAsync();
+        }
+
+        public async Task<IEnumerable<string>> GetPendingMigrationsAsync()
+        {
+            return await Database.GetPendingMigrationsAsync();
         }
 
         public async Task<IEnumerable<string>> GetMigrationsListAsync()

--- a/src/GRA.Data/Model/Site.cs
+++ b/src/GRA.Data/Model/Site.cs
@@ -52,14 +52,14 @@ namespace GRA.Data.Model
         public string FromEmailName { get; set; }
         public string FromEmailAddress { get; set; }
 
-        [MaxLength(100)]
+        [MaxLength(255)]
         public string SiteLogoUrl { get; set; }
         [MaxLength(100)]
         public string FacebookAppId { get; set; }
-        [MaxLength(100)]
+        [MaxLength(255)]
         public string FacebookImageUrl { get; set; }
         public bool? TwitterLargeCard { get; set; }
-        [MaxLength(100)]
+        [MaxLength(255)]
         public string TwitterCardImageUrl { get; set; }
         [MaxLength(15)]
         public string TwitterUsername { get; set; }

--- a/src/GRA.Domain.Model/Site.cs
+++ b/src/GRA.Domain.Model/Site.cs
@@ -73,29 +73,29 @@ namespace GRA.Domain.Model
         [DisplayName("From Email Address")]
         public string FromEmailAddress { get; set; }
 
-        [DisplayName("Site Logo Url")]
-        [MaxLength(100)]
+        [DisplayName("Site Logo URL")]
+        [MaxLength(255)]
         public string SiteLogoUrl { get; set; }
-        [DisplayName("Facebook App Id")]
+        [DisplayName("Facebook App ID")]
         [MaxLength(100)]
         public string FacebookAppId { get; set; }
-        [DisplayName("Facebook Image Url")]
-        [MaxLength(100)]
+        [DisplayName("Facebook/Open Graph Image URL")]
+        [MaxLength(255)]
         public string FacebookImageUrl { get; set; }
         [DisplayName("Twitter Large Card")]
         public bool? TwitterLargeCard { get; set; }
-        [DisplayName("Twitter Card ImageUrl")]
-        [MaxLength(100)]
+        [DisplayName("Twitter Card Image URL")]
+        [MaxLength(255)]
         public string TwitterCardImageUrl { get; set; }
         [DisplayName("Twitter Username")]
         [MaxLength(15)]
         public string TwitterUsername { get; set; }
-        [DisplayName("Is Https Forced")]
+        [DisplayName("Is HTTPS Forced")]
         public bool IsHttpsForced { get; set; }
         [DisplayName("Twitter Avatar Message")]
         [MaxLength(255)]
         public string TwitterAvatarMessage { get; set; }
-        [DisplayName("Twitter Avatar Hashtags")]
+        [DisplayName("Twitter Avatar Hashtag")]
         [MaxLength(100)]
         public string TwitterAvatarHashtags { get; set; }
         [DisplayName("Avatar Card Description")]

--- a/src/GRA.Web/Areas/MissionControl/Views/Sites/Configuration.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Sites/Configuration.cshtml
@@ -8,6 +8,7 @@
     <div class="row row-spacing">
         <div class="col-xs-12 col-sm-6">
             <label asp-for="SiteLogoUrl" class="control-label"></label>
+            <span class="fa fa-question-circle-o wide-tooltip" title="An image (ideally a transparent, square PNG, 250x250 pixels) representing your program for administration screens (not seen by participants)." data-toggle="tooltip" data-placement="top"></span>
             <input asp-for="SiteLogoUrl" type="text" class="form-control" />
             <span asp-validation-for="SiteLogoUrl" class="text-danger"></span>
         </div>

--- a/src/GRA.Web/Areas/MissionControl/Views/Sites/SocialMedia.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Sites/SocialMedia.cshtml
@@ -14,7 +14,7 @@
             <span asp-validation-for="FacebookAppId" class="text-danger"></span>
         </div>
         <div class="col-xs-12 col-sm-6">
-            <label asp-for="FacebookImageUrl" class="control-label">Facebook/Open Graph Image URL</label>
+            <label asp-for="FacebookImageUrl" class="control-label"></label>
             <span class="fa fa-question-circle-o wide-tooltip" title="URL to an Open Graph image to be used when your site is shared" data-toggle="tooltip" data-placement="top"></span>
             <a href="http://ogp.me/" target="_blank"><span class="fa fa-info-circle wide-tooltip" title="Click for more info" data-toggle="tooltip" data-placement="top"></span></a>
             <input asp-for="FacebookImageUrl" type="text" class="form-control" />
@@ -30,7 +30,7 @@
             <span asp-validation-for="TwitterUsername" class="text-danger"></span>
         </div>
         <div class="col-xs-12 col-sm-6">
-            <label asp-for="TwitterCardImageUrl" class="control-label">Twitter Card Image URL</label>
+            <label asp-for="TwitterCardImageUrl" class="control-label"></label>
             <span class="fa fa-question-circle-o wide-tooltip" title="URL to a Twitter image to be used when your site is shared" data-toggle="tooltip" data-placement="top"></span>
             <a href="https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/abouts-cards" target="_blank"><span class="fa fa-info-circle wide-tooltip" title="Click for more info" data-toggle="tooltip" data-placement="top"></span></a>
             <input asp-for="TwitterCardImageUrl" type="text" class="form-control" />

--- a/src/GRA.Web/Views/Join/AuthorizationCode.cshtml
+++ b/src/GRA.Web/Views/Join/AuthorizationCode.cshtml
@@ -1,13 +1,19 @@
 ﻿@model GRA.Controllers.ViewModel.Join.AuthorizationCodeViewModel
 
 <form asp-action="AuthorizationCode" method="post">
-
     <div class="row">
         <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-8 col-md-offset-2">
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <span class="lead"><grasite property="name"></grasite> - Authorization</span>
                 </div>
+                <div class="col-xs-12">
+                    <img class="center-block"
+                         src="@Model.SiteLogoUrl"
+                         width="250"
+                         height="250" />
+                </div>
+
                 <div class="panel-body">
                     <div class="form-group form-group-lg">
                         <label asp-for="AuthorizationCode" class="h4"></label>


### PR DESCRIPTION
- :card_index: Includes database changes - expand `Site` fields
  `TwitterCardImageUrl`, `SiteLogoUrl` and `FacebookImageUrl` to 255
  characters
- Fix typo in authorization error message
- Show Site Logo URL on join with authorization code
- Fix #294 expand site logo URL to 255 characters
- Expand Open Graph/Facebook and Twitter image URLs to 255 characters
- Log when migrations are applied at application startup
- Improve site management field descriptions and explanations further