### PR TITLE
Fix title of page for community experiences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Unreleased
+### Fixed
+- Fix page title to "community experiences" when selected on the events page
+
 ## [4.0.0-beta2] - 2018-05-18
 ### Added
 - Group Vendor Code Report: group members and their assigned vendor codes

--- a/src/GRA.Controllers/MissionControl/EventsController.cs
+++ b/src/GRA.Controllers/MissionControl/EventsController.cs
@@ -88,6 +88,7 @@ namespace GRA.Controllers.MissionControl
                         });
                 }
                 viewModel.CommunityExperience = true;
+                PageTitle = "Community Experiences";
                 return View("Index", viewModel);
             }
             catch (Exception ex)


### PR DESCRIPTION
- Set title of events page to "community experiences" when selected