### PR TITLE
Fix title of public page for community experiences

### DIFF
--- a/src/GRA.Controllers/EventsController.cs
+++ b/src/GRA.Controllers/EventsController.cs
@@ -40,6 +40,7 @@ namespace GRA.Controllers
             string StartDate = null,
             string EndDate = null)
         {
+            PageTitle = "Community Experiences";
             return await Index(page, search, system, branch, location, program, StartDate, EndDate, true);
         }
 


### PR DESCRIPTION
- Set title of public events page to "community experiences" when
  selected