### PR TITLE
Add Docker build script, push to Docker Hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,3 +267,6 @@ src/GRA.CommandLine/Properties/PublishProfiles/
 
 # exclude bootstrap-multiselect TS project file
 src/GRA.Web/wwwroot/lib/bootstrap-multiselect/types/bootstrap-multiselect/tsconfig.json
+
+# include developer build scripts
+!dev/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,17 @@ services:
   - docker
 
 script: bash dev/bin/docker-build.sh
+
+after_success:
+  - |
+    if [[ "$DOCKER_USERNAME" != "" ]] && [[ "$DOCKER_PASSWORD" != "" ]]; then
+        if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push mcld/gra:latest
+          docker logout
+        elif [[ "$TRAVIS_BRANCH" == "develop" ]]; then
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push mcld/gra:$TRAVIS_BRANCH
+          docker logout
+        fi
+    fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 - Mission Control events navbar icon is now a drop-down (#322)
+- Fix automated builds and pushing to Docker Hub
 
 ### Fixed
 - Set page title to "community experiences" when selected on the events page

--- a/dev/bin/docker-build.sh
+++ b/dev/bin/docker-build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+pwd=${PWD##*/}
+
+if [ $pwd = "bin" ]; then
+  cd ..
+fi
+
+pwd=${PWD##*/}
+
+if [ $pwd = "dev" ]; then
+  cd ..
+fi
+
+BRANCH=`git name-rev --name-only HEAD`
+COMMIT=`git rev-parse --short HEAD`
+
+echo -e "\e[1mBuilding GRA branch \e[96m$BRANCH\e[39m commit \e[93m$COMMIT\e[0m"
+
+if [[ "$BRANCH" == "master" ]]; then
+  export TAG="latest";
+  export DOCKERFILE="Dockerfile"
+elif [[ "$BRANCH" == "develop" ]]; then
+  export TAG="develop";
+  export DOCKERFILE="dev/Dockerfile"
+  echo -e "\e[1m\e[41mAutomatically adding a database migration for $BRANCH branch\e[0m"
+else
+  export TAG=$COMMIT;
+  export DOCKERFILE="Dockerfile"
+fi
+
+docker build -f $DOCKERFILE -t mcld/gra:$TAG --build-arg commit="$COMMIT" .


### PR DESCRIPTION
- Add Docker build script (fix .gitignore)
- Have Travis push to Docker Hub when appropriate