### PR TITLE
Remove RuntimeFrameworkVersion from .csproj files

### DIFF
--- a/src/GRA.Data.SQLite/GRA.Data.SQLite.csproj
+++ b/src/GRA.Data.SQLite/GRA.Data.SQLite.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <AssemblyName>GRA.Data.SQLite</AssemblyName>
     <PackageId>GRA.Data.SQLite</PackageId>
-    <RuntimeFrameworkVersion>1.1.0</RuntimeFrameworkVersion>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/GRA.Data.SqlServer/GRA.Data.SqlServer.csproj
+++ b/src/GRA.Data.SqlServer/GRA.Data.SqlServer.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <AssemblyName>GRA.Data.SqlServer</AssemblyName>
     <PackageId>GRA.Data.SqlServer</PackageId>
-    <RuntimeFrameworkVersion>1.1.0</RuntimeFrameworkVersion>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <UserSecretsId>gra-e773e45a-3078-4b1b-842d-c7a8f7d310a6</UserSecretsId>
-    <RuntimeFrameworkVersion>1.1.0</RuntimeFrameworkVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <Version>4.0.0-beta2</Version>
     <Authors>GRA.Web</Authors>


### PR DESCRIPTION
Remove specific `RuntimeFrameworkVersion` references from .csproj - as long as it's `netcoreapp1.1` the specific version shouldn't matter.