### PR TITLE
Fix Docker build

### DIFF
--- a/dev/bin/docker-build.sh
+++ b/dev/bin/docker-build.sh
@@ -27,7 +27,7 @@ elif [[ "$BRANCH" == "develop" ]]; then
   export DOCKERFILE="dev/Dockerfile"
   echo -e "\e[1m\e[41mAutomatically adding a database migration for $BRANCH branch\e[0m"
 else
-  export TAG=$BRANCH;
+  export TAG=$COMMIT;
   export DOCKERFILE="Dockerfile"
 fi
 


### PR DESCRIPTION
- Docker tags are more restrictive than git branch names so use the
  commit id as the Docker tag rather than the branch name