### PR TITLE
Fix development version number to 4.1.2-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Unreleased
+### Changed
+- Modify docker-build.bash to not build release images unless the branch starts with 'release/'
+
 ## [4.1.1] - 2018-12-13
 ### Added
 - Add site.js to shared folder for customizing site scripting

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: ubuntu
 stack: docker
 test: off
-version: 4.1.1-{build}
+version: 4.1.2-{build}
 
 build_script:
 - bash docker-build.bash

--- a/docker-build.bash
+++ b/docker-build.bash
@@ -37,7 +37,7 @@ elif [[ $BLD_BRANCH = "develop" ]]; then
   BLD_PUSH=true
   BLD_DOCKERFILE="dev/Dockerfile"
   echo "=== Using $BLD_DOCKERFILE to add database migration for $BLD_BRANCH build..."
-elif [[ $BLD_BRANCH =~ v([0-9]+\.[0-9]+\.[0-9]+.*) || $BLD_BRANCH =~ release/([0-9]+\.[0-9]+\.[0-9]+.*) ]]; then
+elif [[ $BLD_BRANCH =~ release/([0-9]+\.[0-9]+\.[0-9]+.*) ]]; then
   BLD_RELEASE_VERSION=${BASH_REMATCH[1]}
   BLD_DOCKER_TAG=v${BLD_RELEASE_VERSION}
   BLD_RELEASE=true

--- a/src/GRA.CommandLine/GRA.CommandLine.csproj
+++ b/src/GRA.CommandLine/GRA.CommandLine.csproj
@@ -15,7 +15,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA.Controllers/GRA.Controllers.csproj
+++ b/src/GRA.Controllers/GRA.Controllers.csproj
@@ -21,7 +21,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA.Data.SQLite/GRA.Data.SQLite.csproj
+++ b/src/GRA.Data.SQLite/GRA.Data.SQLite.csproj
@@ -20,7 +20,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA.Data.SqlServer/GRA.Data.SqlServer.csproj
+++ b/src/GRA.Data.SqlServer/GRA.Data.SqlServer.csproj
@@ -20,7 +20,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA.Data/GRA.Data.csproj
+++ b/src/GRA.Data/GRA.Data.csproj
@@ -21,7 +21,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA.Domain.Model/GRA.Domain.Model.csproj
+++ b/src/GRA.Domain.Model/GRA.Domain.Model.csproj
@@ -20,7 +20,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA.Domain.Report/GRA.Domain.Report.csproj
+++ b/src/GRA.Domain.Report/GRA.Domain.Report.csproj
@@ -14,7 +14,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA.Domain.Repository/GRA.Domain.Repository.csproj
+++ b/src/GRA.Domain.Repository/GRA.Domain.Repository.csproj
@@ -21,7 +21,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA.Domain.Service/GRA.Domain.Service.csproj
+++ b/src/GRA.Domain.Service/GRA.Domain.Service.csproj
@@ -21,7 +21,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA.Security/GRA.Security.csproj
+++ b/src/GRA.Security/GRA.Security.csproj
@@ -20,7 +20,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -23,7 +23,7 @@
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <UserSecretsId>gra-e773e45a-3078-4b1b-842d-c7a8f7d310a6</UserSecretsId>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GRA/GRA.csproj
+++ b/src/GRA/GRA.csproj
@@ -20,7 +20,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/mcld/greatreadingadventure/</RepositoryUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.1.1</Version>
+    <Version>4.1.2-beta</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Modify docker-build.bash to not build release images unless the branch
starts with 'release/'