### PR TITLE
Update package references; fix StackExchange.Redis

### DIFF
--- a/src/GRA.CommandLine/GRA.CommandLine.csproj
+++ b/src/GRA.CommandLine/GRA.CommandLine.csproj
@@ -20,14 +20,14 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="[6.0.2]" />
-    <PackageReference Include="Bogus" Version="25.0.2" />
+    <PackageReference Include="Bogus" Version="25.0.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.0.1" />

--- a/src/GRA.Controllers/GRA.Controllers.csproj
+++ b/src/GRA.Controllers/GRA.Controllers.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0005" allowedVersions="[1.0.0-beta0005]" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0005" allowedVersions="[1.0.0-beta0005]" />
-    <PackageReference Include="SmartFormat.NET" Version="2.3.1.1" />
+    <PackageReference Include="SmartFormat.NET" Version="2.4.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/GRA.Data.SQLite/GRA.Data.SQLite.csproj
+++ b/src/GRA.Data.SQLite/GRA.Data.SQLite.csproj
@@ -29,8 +29,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.1" />
   </ItemGroup>
 
 </Project>

--- a/src/GRA.Data.SqlServer/GRA.Data.SqlServer.csproj
+++ b/src/GRA.Data.SqlServer/GRA.Data.SqlServer.csproj
@@ -29,8 +29,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.1" />
   </ItemGroup>
 
 </Project>

--- a/src/GRA.Data/GRA.Data.csproj
+++ b/src/GRA.Data/GRA.Data.csproj
@@ -33,8 +33,8 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="[2.0.1]" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/src/GRA.Domain.Service/GRA.Domain.Service.csproj
+++ b/src/GRA.Domain.Service/GRA.Domain.Service.csproj
@@ -36,12 +36,12 @@
     <PackageReference Include="ExcelDataReader" Version="3.4.2" />
     <PackageReference Include="MailKit" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="MimeKit" Version="2.1.2" />
-    <PackageReference Include="SmartFormat.NET" Version="2.3.1.1" />
+    <PackageReference Include="SmartFormat.NET" Version="2.4.1" />
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -80,7 +80,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="2.2.0" />
@@ -90,8 +90,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.1" PrivateAssets="All" />
+    <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="1.1.0" />
@@ -103,6 +103,14 @@
     <PackageReference Include="Serilog.Sinks.Slack.Core" Version="0.1.5-beta" />
   </ItemGroup>
 
+  <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'StackExchange.Redis.StrongName'">
+        <Aliases>signed</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
+  
   <ItemGroup>
     <DotNetCliToolReference Include="BundlerMinifier.Core" Version="2.*" />
   </ItemGroup>

--- a/src/GRA.Web/Startup.cs
+++ b/src/GRA.Web/Startup.cs
@@ -137,7 +137,7 @@ namespace GRA.Web
                     });
                     var redis = ConnectionMultiplexer.Connect(redisConfig);
                     services.AddDataProtection(_ => _.ApplicationDiscriminator = discriminator)
-                        .PersistKeysToRedis(redis, $"grainternal.{discriminator}.dpk")
+                        .PersistKeysToStackExchangeRedis(redis, $"grainternal.{discriminator}.dpk")
                         .SetApplicationName(discriminator);
                     _logger.LogInformation("Using Redis distributed cache {0} discriminator {1}",
                         redisConfig,


### PR DESCRIPTION
- Add Microsoft.AspNetCore.DataProtection.StackExchangeRedis to GRA.Web
- Update GRA.Web.csproj to not reference StackExchange.Redis.StrongName
transitively via Microsoft.Extensions.Caching.Redis
- Bogus 25.0.2 -> 25.0.3
- Microsoft.EntityFrameworkCore 2.2.0 -> 2.2.1
- Microsoft.EntityFrameworkCore.Design 2.2.0 -> 2.2.1
- Microsoft.EntityFrameworkCore.Relational 2.2.0 -> 2.2.1
- Microsoft.EntityFrameworkCore.SqlServer 2.2.0 -> 2.2.1
- Microsoft.EntityFrameworkCore.Sqlite 2.2.0 -> 2.2.1
- Microsoft.VisualStudio.Web.CodeGeneration.Design 2.2.0 -> 2.2.1
- Serilog 2.7.1 -> 2.8.0
- SmartFormat.NET 2.3.1.1 -> 2.4.1