### PR TITLE
Log trigger awards that take more than 5 seconds

### DIFF
--- a/src/GRA.Controllers/MissionControl/ParticipantsController.cs
+++ b/src/GRA.Controllers/MissionControl/ParticipantsController.cs
@@ -536,9 +536,12 @@ namespace GRA.Controllers.MissionControl
                 sw.Start();
                 await _activityService.AwardUserTriggersAsync(viewModel.User.Id, false);
                 sw.Stop();
-                _logger.LogDebug("MC access of user id {UserId} took {Elapsed} to award triggers.",
-                    viewModel.User.Id,
-                    sw.Elapsed.ToString("c"));
+                if(sw.Elapsed.TotalSeconds > 5)
+                {
+                    _logger.LogInformation("MC access of user id {UserId} took {Elapsed} to award triggers.",
+                        viewModel.User.Id,
+                        sw.Elapsed.ToString("c"));
+                }
 
                 if (UserHasPermission(Permission.ViewUserPrizes))
                 {
@@ -883,9 +886,12 @@ namespace GRA.Controllers.MissionControl
                     sw.Start();
                     await _activityService.AwardUserTriggersAsync(head.Id, true);
                     sw.Stop();
-                    _logger.LogDebug("MC access of family/group for user id {UserId} took {Elapsed} to award triggers.",
-                        head.Id,
-                        sw.Elapsed.ToString("c"));
+                    if (sw.Elapsed.TotalSeconds > 5)
+                    {
+                        _logger.LogInformation("MC access of family/group for user id {UserId} took {Elapsed} to award triggers.",
+                            head.Id,
+                            sw.Elapsed.ToString("c"));
+                    }
                     head.HasUnclaimedPrize = (await _prizeWinnerService
                         .GetUserWinCount(head.Id, false)) > 0;
                 }

--- a/src/GRA.Controllers/SignInController.cs
+++ b/src/GRA.Controllers/SignInController.cs
@@ -74,7 +74,17 @@ namespace GRA.Controllers
                         await LoginUserAsync(loginAttempt);
                         _logger.LogTrace("Awarding triggers for {Username}", model.Username);
                         await _userService.AwardMissingJoinBadgeAsync(loginAttempt.User.Id);
+
+                        var sw = new System.Diagnostics.Stopwatch();
+                        sw.Start();
                         await _activityService.AwardUserTriggersAsync(loginAttempt.User.Id, true);
+                        sw.Stop();
+                        if (sw.Elapsed.TotalSeconds > 5)
+                        {
+                            _logger.LogInformation("Login for user id {UserId} took {Elapsed} to award triggers.",
+                                loginAttempt.User.Id,
+                                sw.Elapsed.ToString("c"));
+                        }
 
                         _logger.LogTrace("Checking household count for {Username}",
                             model.Username);

--- a/src/GRA.Domain.Service/UserService.cs
+++ b/src/GRA.Domain.Service/UserService.cs
@@ -202,7 +202,17 @@ namespace GRA.Domain.Service
                 .SetUserPasswordAsync(registeredUser.Id, registeredUser.Id, password);
 
             await JoinedProgramNotificationBadge(registeredUser);
+
+            var sw = new System.Diagnostics.Stopwatch();
+            sw.Start();
             await _activityService.AwardUserTriggersAsync(registeredUser.Id, false);
+            sw.Stop();
+            if (sw.Elapsed.TotalSeconds > 5)
+            {
+                _logger.LogInformation("Registration for user id {UserId} took {Elapsed} to award triggers.",
+                    registeredUser.Id,
+                    sw.Elapsed.ToString("c"));
+            }
 
             return registeredUser;
         }
@@ -649,7 +659,18 @@ namespace GRA.Domain.Service
                 }
 
                 await JoinedProgramNotificationBadge(registeredUser);
+
+                var sw = new System.Diagnostics.Stopwatch();
+                sw.Start();
                 await _activityService.AwardUserTriggersAsync(registeredUser.Id, false);
+                sw.Stop();
+                if (sw.Elapsed.TotalSeconds > 5)
+                {
+                    _logger.LogInformation("Registration for household member {UserId} took {Elapsed} to award triggers.",
+                        registeredUser.Id,
+                        sw.Elapsed.ToString("c"));
+                }
+
                 return registeredUser;
             }
             else

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.1.2.47</FileVersion>
+    <FileVersion>4.1.2.48</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
- Remove debug logging of trigger award timing
- Log any trigger awarding at level info that takes more than 5 seconds