### PR TITLE
Tune bulk email operations

### DIFF
--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.1.2.52</FileVersion>
+    <FileVersion>4.1.2.53</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
- Take 30 records each loop
- Sleep 1 second between sending batches instead of 5
- Send status updates every 5 seconds instead of 15
- Use sent + skipped + problems for computation of percentages
- Don't measure problems as "sent" in counters