### PR TITLE
Add auto expand if only one performer system

### DIFF
--- a/src/GRA.Controllers/ViewModel/MissionControl/PerformerManagement/StatusViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/PerformerManagement/StatusViewModel.cs
@@ -17,5 +17,15 @@ namespace GRA.Controllers.ViewModel.MissionControl.PerformerManagement
         public int ProgramCount { get; set; }
         public int KitCount { get; set; }
         public string SchedulingStage { get; set; }
+
+        public string CollapsePanel
+        {
+            get
+            {
+                return Systems.Count != 1
+                    ? "collapse"
+                    : "";
+            }
+        }
     }
 }

--- a/src/GRA.Web/Areas/MissionControl/Views/PerformerManagement/Index.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/PerformerManagement/Index.cshtml
@@ -63,7 +63,7 @@
                         </h4>
                     </div>
                     <div id="collapse-@system.Id"
-                         class="panel-collapse collapse"
+                         class="panel-collapse @Model.CollapsePanel"
                          role="tabpanel"
                          aria-labelledby="heading-@system.Id">
                         <div class="panel-body">


### PR DESCRIPTION
When viewing the performer management index, automatically expand the
system if there is only one listed