### PR TITLE
Fix reverse proxy IP logging, session parameters

### DIFF
--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.1.2.61</FileVersion>
+    <FileVersion>4.1.2.62</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
- Fix reverse proxy configuration so that it happens prior to logging enrichment
- Try to eliminate "Error unprotecting the session cookie" warnings