### PR TITLE
Fix system/branch export cut-off

### DIFF
--- a/src/GRA.Domain.Service/BranchImportExportService.cs
+++ b/src/GRA.Domain.Service/BranchImportExportService.cs
@@ -55,6 +55,8 @@ namespace GRA.Domain.Service
             await csv.WriteRecordsAsync(branches.OrderBy(_ => _.SystemName).ThenBy(_ => _.Name));
 
             await csv.FlushAsync();
+            await writer.FlushAsync();
+            await memoryStream.FlushAsync();
 
             return memoryStream.ToArray();
         }

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.2.0.5</FileVersion>
+    <FileVersion>4.2.0.6</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
Without flushing all three streams the file was being sent before it was complete.