### PR TITLE
Allow special characters in authorization codes

### DIFF
--- a/manual/installation/configuration.md
+++ b/manual/installation/configuration.md
@@ -31,7 +31,9 @@ For password generation, please consider using a utility like [pwgen](https://gi
   "GraInitialAuthCode": "<authorizationcode>"
 ```
 
-This is the code that you will use when you set up your administrator account to grant you full access to Mission Control (the administrative interface) of the software. Please change this value to ensure that people who come across your site cannot grant themselves full administrator access!
+This is the code that you will use when you set up your administrator account to grant you full access to Mission Control (the administrative interface) of the software. Please change this value to ensure that people who come across your site cannot grant themselves full administrator access! This code accepts letters, numbers, and special characters - do not use emoji. Any trailing whitespace will be ignored and it is case-insensitive (i.e. upper and lower case is ignored).
+
+**Please note:** You must escape special characters as above, consider avoiding backslash (`\`) and double quote (`"`) characters.
 
 ### Sample configuration file
 

--- a/src/GRA.Controllers/JoinController.cs
+++ b/src/GRA.Controllers/JoinController.cs
@@ -304,7 +304,7 @@ namespace GRA.Controllers
                     string sanitized = null;
                     if (!string.IsNullOrWhiteSpace(model.AuthorizationCode))
                     {
-                        sanitized = _codeSanitizer.Sanitize(model.AuthorizationCode, 255);
+                        sanitized = model.AuthorizationCode.Trim().ToLowerInvariant();
                         useAuthCode = await _authorizationCodeService
                             .ValidateAuthorizationCode(sanitized);
                         if (!useAuthCode)
@@ -781,7 +781,7 @@ namespace GRA.Controllers
                     string sanitized = null;
                     if (!string.IsNullOrWhiteSpace(step1.AuthorizationCode))
                     {
-                        sanitized = _codeSanitizer.Sanitize(step1.AuthorizationCode, 255);
+                        sanitized = step1.AuthorizationCode.Trim().ToLowerInvariant();
                         useAuthCode = await _authorizationCodeService
                             .ValidateAuthorizationCode(sanitized);
                         if (!useAuthCode)
@@ -883,7 +883,7 @@ namespace GRA.Controllers
             var site = await GetCurrentSiteAsync();
             if (!TempData.ContainsKey(AuthCodeAttempts) || (int)TempData.Peek(AuthCodeAttempts) < 5)
             {
-                var sanitized = _codeSanitizer.Sanitize(model.AuthorizationCode, 255);
+                var sanitized = model.AuthorizationCode.Trim().ToLowerInvariant();
                 if (await _authorizationCodeService.ValidateAuthorizationCode(sanitized))
                 {
                     TempData.Remove(AuthCodeAttempts);

--- a/src/GRA.Controllers/MissionControl/HomeController.cs
+++ b/src/GRA.Controllers/MissionControl/HomeController.cs
@@ -227,7 +227,7 @@ namespace GRA.Controllers.MissionControl
 
             if (viewmodel != null && ModelState.IsValid)
             {
-                string sanitized = _codeSanitizer.Sanitize(viewmodel.AuthorizationCode, 255);
+                string sanitized = viewmodel.AuthorizationCode.Trim().ToLowerInvariant();
 
                 try
                 {

--- a/src/GRA.Controllers/MissionControl/RolesController.cs
+++ b/src/GRA.Controllers/MissionControl/RolesController.cs
@@ -138,7 +138,7 @@ namespace GRA.Controllers.MissionControl
         [HttpPost]
         public async Task<IActionResult> Edit(RoleDetailViewModel model)
         {
-            model.SelectedPermissions = model.Permissions?.Split(',') ?? new string[] { };
+            model.SelectedPermissions = model.Permissions?.Split(',') ?? Array.Empty<string>();
             if (ModelState.IsValid)
             {
                 await _roleService.EditAsync(model.Role, model.SelectedPermissions);
@@ -161,12 +161,13 @@ namespace GRA.Controllers.MissionControl
 
             var authorizationCodeList = await _authorizationCodeService.GetPaginatedListAsync(filter);
 
-            PaginateViewModel paginateModel = new PaginateViewModel()
+            var paginateModel = new PaginateViewModel
             {
                 ItemCount = authorizationCodeList.Count,
                 CurrentPage = page,
                 ItemsPerPage = filter.Take.Value
             };
+
             if (paginateModel.PastMaxPage)
             {
                 return RedirectToRoute(
@@ -189,10 +190,15 @@ namespace GRA.Controllers.MissionControl
         [HttpPost]
         public async Task<IActionResult> AddCode(AuthorizationCodeListViewModel model)
         {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
             try
             {
-                model.AuthorizationCode.Code.Trim();
-                model.AuthorizationCode.Description?.Trim();
+                model.AuthorizationCode.Code = model.AuthorizationCode.Code.Trim();
+                model.AuthorizationCode.Description = model.AuthorizationCode.Description?.Trim();
                 await _authorizationCodeService.AddAsync(model.AuthorizationCode);
                 ShowAlertSuccess($"Added Authorization Code \"{model.AuthorizationCode.Code}\"!");
             }
@@ -209,10 +215,15 @@ namespace GRA.Controllers.MissionControl
         [HttpPost]
         public async Task<IActionResult> EditCode(AuthorizationCodeListViewModel model)
         {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
             try
             {
-                model.AuthorizationCode.Code.Trim();
-                model.AuthorizationCode.Description?.Trim();
+                model.AuthorizationCode.Code = model.AuthorizationCode.Code.Trim();
+                model.AuthorizationCode.Description = model.AuthorizationCode.Description?.Trim();
                 await _authorizationCodeService.UpdateAsync(model.AuthorizationCode);
                 ShowAlertSuccess($"Authorization Code \"{model.AuthorizationCode.Code}\" updated!");
             }
@@ -230,6 +241,11 @@ namespace GRA.Controllers.MissionControl
         [HttpPost]
         public async Task<IActionResult> DeleteCode(AuthorizationCodeListViewModel model)
         {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
             try
             {
                 await _authorizationCodeService.RemoveAsync(model.AuthorizationCode.Id);

--- a/src/GRA.Controllers/PerformerRegistration/HomeController.cs
+++ b/src/GRA.Controllers/PerformerRegistration/HomeController.cs
@@ -114,7 +114,7 @@ namespace GRA.Controllers.PerformerRegistration
 
             if (ModelState.IsValid)
             {
-                string sanitized = _codeSanitizer.Sanitize(viewmodel.AuthorizationCode, 255);
+                string sanitized = viewmodel.AuthorizationCode.Trim().ToLowerInvariant();
 
                 try
                 {

--- a/src/GRA.Domain.Service/AuthorizationCodeService.cs
+++ b/src/GRA.Domain.Service/AuthorizationCodeService.cs
@@ -97,7 +97,7 @@ namespace GRA.Domain.Service
 
         public async Task<bool> ValidateAuthorizationCode(string authorizationCode)
         {
-            string fixedCode = authorizationCode.Trim().ToLower();
+            string fixedCode = authorizationCode.Trim().ToLowerInvariant();
             int siteId = GetCurrentSiteId();
             var authCode = await _authorizationCodeRepository.GetByCodeAsync(siteId, fixedCode);
             if (authCode == null)

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.2.0.13</FileVersion>
+    <FileVersion>4.2.0.14</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
I believe the sanitizer for entering secret codes was also being used for authorization codes which was stripping out special characters (like `!` and `@`). I've changed the sanitization of authorization codes to be `.Trim()` to purge trailing whitespace and `.ToLowerInvariant()` to make the codes case-insensitive.