### PR TITLE
Fix news post email subjects; update package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Mission Control household add existing participant list being empty
 - Streaming event missing badge alt-text field
 
+- News posts now include the subject correctly
 
 ## [4.2.0] - 2021-01-04
 

--- a/src/GRA.Domain.Service/GRA.Domain.Service.csproj
+++ b/src/GRA.Domain.Service/GRA.Domain.Service.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="27.0.1" />
+    <PackageReference Include="CsvHelper" Version="27.0.2" />
     <PackageReference Include="ExcelDataReader" Version="3.6.0" />
     <PackageReference Include="MailKit" Version="2.11.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />

--- a/src/GRA.Domain.Service/NewsService.cs
+++ b/src/GRA.Domain.Service/NewsService.cs
@@ -352,6 +352,7 @@ namespace GRA.Domain.Service
             {
                 { "PostCategory", post.CategoryName},
                 { nameof(jobDetails.PostLink), jobDetails.PostLink},
+                { "PostTitle", post.Title },
                 { "PostSummary", post.EmailSummary},
                 { "Preview", $"New post in {jobDetails.SiteName} Mission Control!"},
                 { nameof(jobDetails.SiteLink), jobDetails.SiteLink},

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.2.0.29</FileVersion>
+    <FileVersion>4.2.0.30</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
- News post email subjects now include the news title
- Update CSVHelper 27.0.1 -> 27.0.2