### PR TITLE
Add error handling for invalid image types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Fix bug binding performer archiving and streaming choices
 - Hide branch selection in performer scheduling when no branches are available
 - Mission Control error if a user who posted a news post was deleted
+- Show friendly message when invalid image type is uploaded
 
 ### Updated
 

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.2.1.30</FileVersion>
+    <FileVersion>4.2.1.31</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
- Uploaded images that were not decodeable returned a 500 error
- Catch that error and show a nice error to the end user
- Discovered issue outlined in #863