### PR TITLE
Fix trigger attachment upload/remove errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - System setting to disable badge maker
 - System setting to configure background color
 - Downloadable ZIP files of badge images for each system from Mission Control
-- Ability to attach a certificate (uploaded PDF) to a trigger
+- Ability to attach, remove, or update a certificate (uploaded PDF) to a trigger
 
 ### Fixed
 

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -293,21 +293,8 @@ namespace GRA.Controllers.MissionControl
 
                     if (model.AttachmentUploadFile != null)
                     {
-                        string fileName;
-                        using (var ms = new MemoryStream())
-                        {
-                            await model.AttachmentUploadFile.CopyToAsync(ms);
-                            attachmentBytes = ms.ToArray();
-                        }
-                        fileName = Path.GetFileName(model.AttachmentUploadFile.FileName);
-
-                        var newAttachment = new Attachment
-                        {
-                            FileName = fileName
-                        };
-                        var attachment = await _attachmentService.AddAttachmentAsync(newAttachment,
-                            AttachmentService.Certificates,
-                            attachmentBytes);
+                        var attachment = await _attachmentService.AddAttachmentAsync(AttachmentService.Certificates,
+                            model.AttachmentUploadFile);
                         model.Trigger.AwardAttachmentId = attachment.Id;
                     }
                     var trigger = await _triggerService.AddAsync(model.Trigger);
@@ -513,7 +500,6 @@ namespace GRA.Controllers.MissionControl
         public async Task<IActionResult> Edit(TriggersDetailViewModel model)
         {
             byte[] badgeBytes = null;
-            byte[] attachmentBytes = null;
 
             var badgeRequiredList = new List<int>();
             var challengeRequiredList = new List<int>();
@@ -712,41 +698,25 @@ namespace GRA.Controllers.MissionControl
 
                     if (model.AttachmentUploadFile != null)
                     {
-                        using (var ms = new MemoryStream())
-                        {
-                            await model.AttachmentUploadFile.CopyToAsync(ms);
-                            attachmentBytes = ms.ToArray();
-                        }
+                        var trigger = model.Trigger;
+                        trigger.AwardAttachmentId = null;
+                        await _triggerService.UpdateAsync(trigger);
 
-                        if (model.Trigger.AwardAttachmentId != null)
-                        {
-                            var existingAttachment = await _attachmentService
-                            .GetByIdAsync(model.Trigger.AwardAttachmentId.Value);
-
-                            await _attachmentService.ReplaceAttachmentFileAsync(existingAttachment,
+                        var newAttachment = model.Trigger.AwardAttachmentId.HasValue
+                            ? await _attachmentService.ReplaceAttachmentFileAsync(model.Trigger.AwardAttachmentId.Value,
                                 AttachmentService.Certificates,
-                                attachmentBytes);
-                        }
-                        else
-                        {
-                            var attachment = new Attachment
-                            {
-                                FileName = Path.GetFileName(model.AttachmentUploadFile.FileName)
-                            };
-
-                            attachment = await _attachmentService.AddAttachmentAsync(attachment,
-                                AttachmentService.Certificates,
-                                attachmentBytes);
-                            model.Trigger.AwardAttachmentId = attachment.Id;
-                        }
+                                model.AttachmentUploadFile)
+                            : await _attachmentService.AddAttachmentAsync(AttachmentService.Certificates,
+                                model.AttachmentUploadFile);
+                        model.Trigger.AwardAttachmentId = newAttachment?.Id;
                     }
                     var savedtrigger = await _triggerService.UpdateAsync(model.Trigger);
 
-                    if (model.RemoveAttachment)
+                    if (model.RemoveAttachment && model.AttachmentUploadFile == null)
                     {
                         if (model.Trigger.AwardAttachmentId.HasValue)
                         {
-                            await _attachmentService.RemoveAttachmentFile(model.Trigger.AwardAttachmentId.Value);
+                            await _attachmentService.RemoveAttachmentFileAsync(model.Trigger.AwardAttachmentId.Value);
                         }
                         model.Trigger.AwardAttachmentFilename = "";
                         model.Trigger.AwardAttachmentId = null;

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -698,12 +698,16 @@ namespace GRA.Controllers.MissionControl
 
                     if (model.AttachmentUploadFile != null)
                     {
-                        var trigger = model.Trigger;
-                        trigger.AwardAttachmentId = null;
-                        await _triggerService.UpdateAsync(trigger);
+                        var existingAttachmentId = model.Trigger.AwardAttachmentId;
+                        if (existingAttachmentId.HasValue)
+                        {
+                            var trigger = model.Trigger;
+                            trigger.AwardAttachmentId = null;
+                            await _triggerService.UpdateAsync(trigger);
+                        }
 
-                        var newAttachment = model.Trigger.AwardAttachmentId.HasValue
-                            ? await _attachmentService.ReplaceAttachmentFileAsync(model.Trigger.AwardAttachmentId.Value,
+                        var newAttachment = existingAttachmentId.HasValue
+                            ? await _attachmentService.ReplaceAttachmentFileAsync(existingAttachmentId.Value,
                                 AttachmentService.Certificates,
                                 model.AttachmentUploadFile)
                             : await _attachmentService.AddAttachmentAsync(AttachmentService.Certificates,

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -655,11 +655,6 @@ namespace GRA.Controllers.MissionControl
                         model.Trigger.AwardMailSubject = "";
                         model.Trigger.AwardMail = "";
                     }
-                    if (!model.AwardsAttachment && model.EditAttachment)
-                    {
-                        model.Trigger.AwardAttachmentFilename = "";
-                        model.Trigger.AwardAttachmentId = null;
-                    }
                     var existing = await _badgeService
                         .GetByIdAsync(model.Trigger.AwardBadgeId);
                     string fileName;
@@ -746,6 +741,17 @@ namespace GRA.Controllers.MissionControl
                         }
                     }
                     var savedtrigger = await _triggerService.UpdateAsync(model.Trigger);
+
+                    if (model.RemoveAttachment)
+                    {
+                        if (model.Trigger.AwardAttachmentId.HasValue)
+                        {
+                            await _attachmentService.RemoveAttachmentFile(model.Trigger.AwardAttachmentId.Value);
+                        }
+                        model.Trigger.AwardAttachmentFilename = "";
+                        model.Trigger.AwardAttachmentId = null;
+                    }
+
                     ShowAlertSuccess($"Trigger '<strong>{savedtrigger.Name}</strong>' was successfully modified");
                     return RedirectToAction("Index");
                 }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
@@ -14,6 +14,7 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public bool AwardsAttachment { get; set; }
         public bool AwardsMail { get; set; }
         public bool AwardsPrize { get; set; }
+
         [DisplayName("Badge Alternative Text")]
         [MaxLength(255)]
         public string BadgeAltText { get; set; }
@@ -39,10 +40,13 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public string MaxPointsWarningMessage { get; set; }
         public SelectList ProgramList { get; set; }
         public ICollection<Event> RelatedEvents { get; set; }
+        public bool RemoveAttachment { get; set; }
         public SelectList SystemList { get; set; }
         public GRA.Domain.Model.Trigger Trigger { get; set; }
+
         [DisplayName("Challenges and triggers the participant must have earned")]
         public ICollection<TriggerRequirement> TriggerRequirements { get; set; }
+
         public string UnlockableAvatarBundle { get; set; }
         public SelectList UnlockableAvatarBundleList { get; set; }
         public bool UseBadgeMaker { get; set; }

--- a/src/GRA.Domain.Service/AttachmentService.cs
+++ b/src/GRA.Domain.Service/AttachmentService.cs
@@ -54,8 +54,20 @@ namespace GRA.Domain.Service
             return await _attachmentRepository.GetByIdAsync(attachmentId);
         }
 
+        public async Task RemoveAttachmentFile(int attachmentId)
+        {
+            var attachment = await _attachmentRepository.GetByIdAsync(attachmentId);
+            if (attachment == null)
+            {
+                throw new GraException("Attachment does not exist.");
+            }
+            File.Delete("shared/content/" + attachment.FileName);
+            await _attachmentRepository.RemoveSaveAsync(GetClaimId(ClaimType.UserId),
+                attachmentId);
+        }
+
         public async Task<Attachment> ReplaceAttachmentFileAsync(Attachment attachment,
-            string attachmentType,
+                    string attachmentType,
             byte[] file)
         {
             VerifyManagementPermission();

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
@@ -615,8 +615,8 @@
                 <div id="collapseAttachment" class="panel-collapse collapse @(Model.AwardsAttachment ? "in" : "")" role="tabpanel" aria-labelledby="headingAttachment">                   
                     <div class="panel-body">
                         <div class="row row-spacing">
-                            <div class="col-xs-12">
-                                <p>@(Model.Action == "Edit" ? "Replace the" : "Upload an") attachment.</p>
+                            <div class="col-xs-12" id="uploadAttachmentContainer" style="display:@(Model.EditAttachment && Model.AwardsAttachment ? "none" : "")">
+                                <p>@(Model.Action == "Edit" && Model.AwardsAttachment ? "Replace the" : "Upload an") attachment.</p>
                                 <div class="input-group">
                                     <label class="input-group-btn">
                                         <span id="selectAttachment" class="btn btn-default btn-file">
@@ -634,12 +634,15 @@
                                 @if (Model.AwardsAttachment && !string.IsNullOrWhiteSpace(Model.Trigger.AwardAttachmentFilename))
                                 {
                                 <div class="container" style="margin-top:1.5rem;">
-                                        <a class="btn btn-primary" href="~/@Model.Trigger.AwardAttachmentFilename" target="_blank">
-                                            <img id="attachmentImage" width="15"
-                                                src="~/images/certificate.png" />
-                                            <span>View attachment</span>
-                                        </a>
-                                    <button type="button" class="btn btn-danger" id="btn-remove-attachment">
+                                    <a class="btn btn-primary btn-md" href="~/@Model.Trigger.AwardAttachmentFilename" target="_blank">
+                                        <img id="attachmentImage" width="20"
+                                            src="~/images/certificate.png" />
+                                        <span>View attachment</span>
+                                    </a>
+                                    <button type="button" class="btn btn-default btn-md" id="btn-replace-attachment">
+                                        <span>Replace attachment</span>
+                                    </button>
+                                    <button type="button" class="btn btn-danger btn-md" id="btn-remove-attachment">
                                         <span>Remove attachment</span>
                                     </button>
                                 </div>
@@ -1070,7 +1073,17 @@
 
         $("#btn-remove-attachment").on("click", function() {
             $("#removeAttachmentContainer").hide();
+            $("#uploadAttachmentContainer").show();
             $("#RemoveAttachment").val(true);
+        });
+
+        $("#AttachmentUploadFile").on("change", function() {
+            $("#removeAttachmentContainer").remove();
+        });
+
+        $("#btn-replace-attachment").on("click", function() {
+            $("#uploadAttachmentContainer").show();
+            $("#btn-replace-attachment").hide();
         });
 
         $("#Trigger_SecretCode").on("blur", function () {

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
@@ -618,13 +618,16 @@
                         <div class="row row-spacing">
                             <div class="col-xs-12" id="uploadAttachmentContainer">
                                 <p id="uploadAttachmentHeader">
-                                    @if (Model.Trigger.AwardAttachmentId.HasValue && Model.RemoveAttachment)
+                                    @if (Model.AwardsAttachment)
                                     {
-                                        @:Attachment will be removed when this trigger is saved. <br /> Click "Return to List" to cancel attachment removal
-                                    }
-                                    else if (Model.Trigger.AwardAttachmentId.HasValue)
-                                    {
-                                        @: Select a file to replace the existing attachment and click "Save Trigger". <br /> Click "Return to List" to cancel attachment replacement.
+                                        if (Model.Trigger.AwardAttachmentId.HasValue && Model.RemoveAttachment)
+                                        {
+                                            @:Attachment will be removed when this trigger is saved. <br /> Click "Return to List" to cancel attachment removal
+                                        }
+                                        else if (Model.Trigger.AwardAttachmentId.HasValue)
+                                        {
+                                            @: Select a file to replace the existing attachment and click "Save Trigger". <br /> Click "Return to List" to cancel attachment replacement.
+                                        }
                                     }
                                     else
                                     {

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
@@ -613,7 +613,6 @@
                 <div id="collapseAttachment" class="panel-collapse collapse @(Model.AwardsAttachment ? "in" : "")" role="tabpanel" aria-labelledby="headingAttachment">                   
                     <div class="panel-body">
                         <div class="row row-spacing">
-                            @if (Model.EditAttachment) {
                             <div class="col-xs-12">
                                 <p>@(Model.Action == "Edit" ? "Replace the" : "Upload an") attachment.</p>
                                 <div class="input-group">
@@ -629,7 +628,6 @@
                                 </div>
                                 <button id="clearAttachment" class="btn btn-default" type="button" style="margin-top: 0.5em;"><span class="fas fa-ban"></span> Clear file selection</button>
                             </div>
-                        }
                         <div class="col-xs-12">
                                 @if (Model.AwardsAttachment && !string.IsNullOrWhiteSpace(Model.Trigger.AwardAttachmentFilename))
                                 {

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
@@ -51,6 +51,7 @@
     <input asp-for="EditMail" type="hidden" />
     <input asp-for="EditVendorCode" type="hidden" />
     <input asp-for="EditAvatarBundle" type="hidden" />
+    <input asp-for="EditAttachment" type="hidden" />
     <input asp-for="AwardsPrize" type="hidden" />
     <input asp-for="AwardsMail" type="hidden" />
     <input asp-for="AwardsAttachment" type="hidden" />
@@ -61,6 +62,7 @@
         <input asp-for="Trigger.RelatedSystemId" type="hidden" />
         <input asp-for="Trigger.AwardBadgeId" type="hidden" />
         <input asp-for="Trigger.AwardAttachmentId" type="hidden" />
+        <input asp-for="RemoveAttachment" type="hidden" />
     }
 
     @if (Model.DependentTriggers?.Count > 0)
@@ -628,17 +630,18 @@
                                 </div>
                                 <button id="clearAttachment" class="btn btn-default" type="button" style="margin-top: 0.5em;"><span class="fas fa-ban"></span> Clear file selection</button>
                             </div>
-                        <div class="col-xs-12">
+                        <div id="removeAttachmentContainer" class="col-xs-12">
                                 @if (Model.AwardsAttachment && !string.IsNullOrWhiteSpace(Model.Trigger.AwardAttachmentFilename))
                                 {
-                                <div class="form-row d-inline-block">
-                                    <div class="col-lg-12" style="margin-top:1.5rem;">
-                                            <a href="~/@Model.Trigger.AwardAttachmentFilename" target="_blank">
-                                        <img id="attachmentImage"
-                                        src="~/images/certificate.png" />
-                                        <span>View attachment</span>
+                                <div class="container" style="margin-top:1.5rem;">
+                                        <a class="btn btn-primary" href="~/@Model.Trigger.AwardAttachmentFilename" target="_blank">
+                                            <img id="attachmentImage" width="15"
+                                                src="~/images/certificate.png" />
+                                            <span>View attachment</span>
                                         </a>
-                                    </div>
+                                    <button type="button" class="btn btn-danger" id="btn-remove-attachment">
+                                        <span>Remove attachment</span>
+                                    </button>
                                 </div>
                                 }
                             </div>
@@ -1063,6 +1066,11 @@
         $("#collapseAttachment").on("hide.bs.collapse", function() {
             $("#AwardsAttachment").val("false");
             $("#attachmentIcon").removeClass("fa-caret-down").addClass("fa-caret-right");
+        });
+
+        $("#btn-remove-attachment").on("click", function() {
+            $("#removeAttachmentContainer").hide();
+            $("#RemoveAttachment").val(true);
         });
 
         $("#Trigger_SecretCode").on("blur", function () {

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
@@ -62,6 +62,7 @@
         <input asp-for="Trigger.RelatedSystemId" type="hidden" />
         <input asp-for="Trigger.AwardBadgeId" type="hidden" />
         <input asp-for="Trigger.AwardAttachmentId" type="hidden" />
+        <input asp-for="Trigger.AwardAttachmentFilename" type="hidden" />
         <input asp-for="RemoveAttachment" type="hidden" />
     }
 
@@ -615,38 +616,61 @@
                 <div id="collapseAttachment" class="panel-collapse collapse @(Model.AwardsAttachment ? "in" : "")" role="tabpanel" aria-labelledby="headingAttachment">                   
                     <div class="panel-body">
                         <div class="row row-spacing">
-                            <div class="col-xs-12" id="uploadAttachmentContainer" style="display:@(Model.EditAttachment && Model.AwardsAttachment ? "none" : "")">
-                                <p>@(Model.Action == "Edit" && Model.AwardsAttachment ? "Replace the" : "Upload an") attachment.</p>
-                                <div class="input-group">
-                                    <label class="input-group-btn">
-                                        <span id="selectAttachment" class="btn btn-default btn-file">
-                                            <span class="far fa-file"></span> Select a file<input type="file" asp-for="AttachmentUploadFile" accept=".pdf" style="display: none;" />
-                                        </span>
-                                    </label>
-                                    <input type="text" class="form-control" readonly id="selectedCertPdf">
-                                </div>
-                                <div>
-                                    <span asp-validation-for="AttachmentUploadFile" class="text-danger"></span>
-                                </div>
-                                <button id="clearAttachment" class="btn btn-default" type="button" style="margin-top: 0.5em;"><span class="fas fa-ban"></span> Clear file selection</button>
-                            </div>
-                        <div id="removeAttachmentContainer" class="col-xs-12">
-                                @if (Model.AwardsAttachment && !string.IsNullOrWhiteSpace(Model.Trigger.AwardAttachmentFilename))
+                            <div class="col-xs-12" id="uploadAttachmentContainer">
+                                <p id="uploadAttachmentHeader">
+                                    @if (Model.Trigger.AwardAttachmentId.HasValue && Model.RemoveAttachment)
+                                    {
+                                        @:Attachment will be removed when this trigger is saved. <br /> Click "Return to List" to cancel attachment removal
+                                    }
+                                    else if (Model.Trigger.AwardAttachmentId.HasValue)
+                                    {
+                                        @: Select a file to replace the existing attachment and click "Save Trigger". <br /> Click "Return to List" to cancel attachment replacement.
+                                    }
+                                    else
+                                    {
+                                        @:Upload an attachment.
+                                    }
+                                </p>
+                                @if (!Model.RemoveAttachment)
                                 {
-                                <div class="container" style="margin-top:1.5rem;">
-                                    <a class="btn btn-primary btn-md" href="~/@Model.Trigger.AwardAttachmentFilename" target="_blank">
-                                        <img id="attachmentImage" width="20"
-                                            src="~/images/certificate.png" />
-                                        <span>View attachment</span>
-                                    </a>
-                                    <button type="button" class="btn btn-default btn-md" id="btn-replace-attachment">
-                                        <span>Replace attachment</span>
-                                    </button>
-                                    <button type="button" class="btn btn-danger btn-md" id="btn-remove-attachment">
-                                        <span>Remove attachment</span>
-                                    </button>
-                                </div>
+                                    <div id="attachmentInputWrapper">
+                                        <div class="input-group">
+                                            <label class="input-group-btn">
+                                                <span id="selectAttachment" class="btn btn-default btn-file">
+                                                    <span class="far fa-file"></span> Select a file<input type="file" asp-for="AttachmentUploadFile" accept=".pdf" style="display: none;" />
+                                                </span>
+                                            </label>
+                                            <input type="text" class="form-control" readonly id="selectedCertPdf">
+                                        </div>
+                                        <div>
+                                            <span asp-validation-for="AttachmentUploadFile" class="text-danger"></span>
+                                        </div>
+                                        <button id="clearAttachment" class="btn btn-default" type="button" style="margin-top: 0.5em;"><span class="fas fa-ban"></span> Clear file selection</button>
+                                    </div>
                                 }
+                                <div id="removeAttachmentContainer">
+                                    @if (Model.AwardsAttachment)
+                                    {                                    
+                                        @if (!string.IsNullOrWhiteSpace(Model.Trigger.AwardAttachmentFilename))
+                                        {
+                                        <div>
+                                            <a class="btn btn-primary" style="margin-top:0.5em;" href="~/@Model.Trigger.AwardAttachmentFilename" target="_blank">
+                                                <img id="attachmentImage" width="20"
+                                                    src="~/images/certificate.png" />
+                                                <span>View Attachment</span>
+                                            </a>
+                                        </div>
+                                        }
+                                        @if (!Model.RemoveAttachment)
+                                        {
+                                        <div>
+                                            <button type="button" class="btn btn-danger" style="margin-top:0.5em;" id="btn-remove-attachment">
+                                                <span>Remove Attachment</span>
+                                            </button>
+                                        </div>
+                                        }
+                                    }
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -1071,19 +1095,11 @@
             $("#attachmentIcon").removeClass("fa-caret-down").addClass("fa-caret-right");
         });
 
-        $("#btn-remove-attachment").on("click", function() {
-            $("#removeAttachmentContainer").hide();
-            $("#uploadAttachmentContainer").show();
+        $("#btn-remove-attachment").on("mouseup", function() {
+            $("#attachmentInputWrapper").hide();
+            $("#uploadAttachmentHeader").text("Attachment will be removed when this trigger is saved. Click “Return to List” to cancel attachment removal.");
             $("#RemoveAttachment").val(true);
-        });
-
-        $("#AttachmentUploadFile").on("change", function() {
-            $("#removeAttachmentContainer").remove();
-        });
-
-        $("#btn-replace-attachment").on("click", function() {
-            $("#uploadAttachmentContainer").show();
-            $("#btn-replace-attachment").hide();
+            $("#btn-remove-attachment").hide();
         });
 
         $("#Trigger_SecretCode").on("blur", function () {

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
@@ -661,7 +661,7 @@
                                             </a>
                                         </div>
                                         }
-                                        @if (!Model.RemoveAttachment)
+                                        @if (!Model.RemoveAttachment && Model.Trigger.AwardAttachmentId.HasValue)
                                         {
                                         <div>
                                             <button type="button" class="btn btn-danger" style="margin-top:0.5em;" id="btn-remove-attachment">

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.4.36</FileVersion>
+    <FileVersion>4.4.37</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
- Fix #994 Trigger add failure causes Award Attachment functionality to be inaccessible
- Fix #999 Added a button to the attachment upload form to allow removal of existing attachments
- Fix #1000 the issue where uploading a new document would not replace an existing trigger attachment