### PR TITLE
Improve Google Analytics, add carousel event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Rename "Redemption Instructions" label to "Redemptions Instructions for Staff"
 - Update to use avatar package 4.2.2
+- Improve Google Analytics to better support GA 4 and events
 
 ## Added
 

--- a/src/GRA.Controllers/ProfileController.cs
+++ b/src/GRA.Controllers/ProfileController.cs
@@ -64,7 +64,7 @@ namespace GRA.Controllers
             VendorCodeService vendorCodeService) : base(context)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _mapper = context.Mapper;
+            _mapper = context?.Mapper;
             _activityService = activityService
                 ?? throw new ArgumentNullException(nameof(activityService));
             _authenticationService = authenticationService
@@ -1166,15 +1166,16 @@ namespace GRA.Controllers
                                         DailyImageMessage = dailyLiteracyTip.Message,
                                         DailyImagePath
                                             = _pathResolver.ResolveContentPath(imagePath),
-                                        IsLarge = dailyLiteracyTip.IsLarge
+                                        IsLarge = dailyLiteracyTip.IsLarge,
+                                        Day = day.Value
                                     };
-                                    dailyImageDictionary.Add(program.Id, dailyImageViewModel);
+                                    viewModel.DailyImageDictionary.Add(program.Id,
+                                        dailyImageViewModel);
                                 }
                             }
                         }
                     }
                 }
-                viewModel.DailyImageDictionary = dailyImageDictionary;
 
                 if (showVendorCodes)
                 {

--- a/src/GRA.Controllers/ViewModel/Home/DashboardViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/Home/DashboardViewModel.cs
@@ -24,13 +24,12 @@ namespace GRA.Controllers.ViewModel.Home
         public string DashboardAlert { get; set; }
         public AlertType DashboardAlertType { get; set; }
         public string DashboardPageContent { get; set; }
+        public int Day { get; set; }
         public bool DisableSecretCode { get; set; }
         public bool FirstTimeParticipant { get; set; }
         public bool HasPendingVendorCodeQuestion { get; set; }
-        public int? SiteActivityPercentComplete { get; set; }
         public int? PercentComplete { get; set; }
         public string ProgramName { get; set; }
-        public int? SiteReadingGoal { get; set; }
         public string ProgressMessage { get; set; }
 
         [DisplayName(DisplayNames.SecretCode)]
@@ -38,6 +37,8 @@ namespace GRA.Controllers.ViewModel.Home
 
         public string SecretCodeMessage { get; set; }
         public bool SingleEvent { get; set; }
+        public int? SiteActivityPercentComplete { get; set; }
+        public int? SiteReadingGoal { get; set; }
         public SiteStage SiteStage { get; set; }
 
         [MaxLength(500, ErrorMessage = ErrorMessages.MinLength)]

--- a/src/GRA.Controllers/ViewModel/Profile/HouseholdListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/Profile/HouseholdListViewModel.cs
@@ -6,29 +6,31 @@ namespace GRA.Controllers.ViewModel.Profile
 {
     public class HouseholdListViewModel
     {
-        public IEnumerable<GRA.Domain.Model.User> Users { get; set; }
-        public int HouseholdCount { get; set; }
-        public bool HasAccount { get; set; }
-        public GRA.Domain.Model.User Head { get; set; }
-        public bool AuthUserIsHead { get; set; }
+        public HouseholdListViewModel()
+        {
+            DailyImageDictionary = new Dictionary<int, DailyImageViewModel>();
+        }
+
         public int ActiveUser { get; set; }
-        public string UserSelection { get; set; }
         public int ActivityAmount { get; set; }
         public string ActivityMessage { get; set; }
+        public bool AuthUserIsHead { get; set; }
+        public bool CanEditHousehold { get; set; }
+        public bool CanLogActivity { get; set; }
+        public IDictionary<int, DailyImageViewModel> DailyImageDictionary { get; }
         public bool DisableSecretCode { get; set; }
+        public EmailAwardViewModel EmailAwardModel { get; set; }
+        public bool GroupLeader { get; set; }
+        public string GroupName { get; set; }
+        public bool HasAccount { get; set; }
+        public GRA.Domain.Model.User Head { get; set; }
+        public int HouseholdCount { get; set; }
+        public string LocalizedHouseholdTitle { get; set; }
+        public PointTranslation PointTranslation { get; set; }
         public string SecretCode { get; set; }
         public string SecretCodeMessage { get; set; }
-        public bool CanLogActivity { get; set; }
-        public bool CanEditHousehold { get; set; }
         public bool ShowVendorCodes { get; set; }
-        public PointTranslation PointTranslation { get; set; }
-
-        public Dictionary<int, DailyImageViewModel> DailyImageDictionary { get; set; }
-        public string GroupName { get; set; }
-        public bool GroupLeader { get; set; }
-
-        public string LocalizedHouseholdTitle { get; set; }
-
-        public EmailAwardViewModel EmailAwardModel { get; set; }
+        public IEnumerable<User> Users { get; set; }
+        public string UserSelection { get; set; }
     }
 }

--- a/src/GRA.Controllers/ViewModel/Shared/DailyImageViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/Shared/DailyImageViewModel.cs
@@ -4,6 +4,7 @@
     {
         public string DailyImageMessage { get; set; }
         public string DailyImagePath { get; set; }
+        public int Day { get; set; }
         public bool IsLarge { get; set; }
     }
 }

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.4.41</FileVersion>
+    <FileVersion>4.4.42</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/GRA.Web/Views/Avatar/Index.cshtml
+++ b/src/GRA.Web/Views/Avatar/Index.cshtml
@@ -234,7 +234,7 @@
         $.ajaxSetup({
             timeout: 30000
         });
-        $( document ).ready(function() {
+        $(document).ready(function () {
             //Sets the default layer
             SetLayer($("#layer-container").find("[data-layer='" + @Model.DefaultLayer +"']"));
             var saveSpinner = $("#saveAvatar").find("span.fa-spinner");
@@ -242,12 +242,12 @@
         });
         //Returns the layer's selected item Id
         function GetLayersSelectedItemId(layerId) {
-            var item = $("img.avatar-layer-selector[data-layer='" + layerId +"']").first();
+            var item = $("img.avatar-layer-selector[data-layer='" + layerId + "']").first();
             return item.data("item");
         }
         //Returns the layer's selected color Id
         function GetLayersSelectedColorId(layerId) {
-            var item = $("img.avatar-layer-selector[data-layer='" + layerId +"']").first();
+            var item = $("img.avatar-layer-selector[data-layer='" + layerId + "']").first();
             return item.data("color");
         }
         //Given a layer ID, returns the layer object
@@ -283,7 +283,7 @@
         }
         //returns the ItemId or ColorId for the first active object & marks it selected
         function SelectGetFirstActiveObjectId(type, layer) {
-            var item = $("#avatar" + type +"s").find(".slick-active").find(".avatar-"+type.toLowerCase()+"-selector").first();
+            var item = $("#avatar" + type + "s").find(".slick-active").find(".avatar-" + type.toLowerCase() + "-selector").first();
             layer.data(type.toLowerCase(), item.data(type.toLowerCase()));
             item.addClass("selected");
             return layer.data(type.toLowerCase());
@@ -301,9 +301,8 @@
             return items;
         }
         //Updates the the layer's image
-        function UpdateAvatarContainer(type,id, srcStr, layerId, hide) {
-            for (var idx = 0; idx < $(".avatar-container").length; idx++)
-            {
+        function UpdateAvatarContainer(type, id, srcStr, layerId, hide) {
+            for (var idx = 0; idx < $(".avatar-container").length; idx++) {
                 var image = $($(".avatar-container")[idx]).find(".image" + layerId);
                 image.data(type, id);
                 image.attr("src", srcStr);
@@ -360,8 +359,7 @@
         $(".avatar-layer-selector").on("click", function () {
             var layer = $(this);
             var currentLayer = CurrentSelectedLayer();
-            if (currentLayer == undefined || layer.data("layer") != currentLayer.data("layer"))
-            {
+            if (currentLayer == undefined || layer.data("layer") != currentLayer.data("layer")) {
                 currentLayer.removeClass("selected");
                 SetLayer(layer);
             }
@@ -378,8 +376,7 @@
                 $("#avatarItems").addClass("hide");
                 $("#removeButton").addClass("hide");
             }
-            else if (layer.data("showitemselector") == "True")
-            {
+            else if (layer.data("showitemselector") == "True") {
                 //If a regular item container is being displayed
                 $("#avatarBundles").addClass("hide");
                 $("#avatarItems").removeClass("hide");
@@ -405,7 +402,7 @@
         }
 
         // Initializes the item/color slicks
-        function SetLayersSelectors(divId,rowCount) {
+        function SetLayersSelectors(divId, rowCount) {
             var drag, infin = true;
             var selected, bundleId, totalitems = 0;
             var selectedIds, slickSettings = [];
@@ -418,29 +415,28 @@
             var layerObj = CurrentSelectedLayer();
             var layerId = $(layerObj).data("layer");
             // if we're dealing with bundles
-            if(layerId == 999) {
+            if (layerId == 999) {
                 selectedIds = GetAllSelectedItems();
                 selectType = "Bundle";
                 bundleId = $("#bundle-selected").data("bundleid");
-            }
-            else{
+            } else {
                 selected = (selectType == "Color") ? GetLayersSelectedColorId(layerId) : GetLayersSelectedItemId(layerId);
             }
             $.ajax(
-            {
-                type: 'GET',
-                traditional: true,
-                contentType: 'application/json; charset=utf-8',
-                data:
                 {
-                    type: selectType,
-                    layerId: layerId,
-                    selectedItemId: $.makeArray(selected),
-                    bundleId: bundleId,
-                    selectedItemIds: selectedIds
-                },
-                dataType: 'html',
-                url: "@Url.Action(nameof(AvatarController.GetLayersItems))",
+                    type: 'GET',
+                    traditional: true,
+                    contentType: 'application/json; charset=utf-8',
+                    data:
+                    {
+                        type: selectType,
+                        layerId: layerId,
+                        selectedItemId: $.makeArray(selected),
+                        bundleId: bundleId,
+                        selectedItemIds: selectedIds
+                    },
+                    dataType: 'html',
+                    url: "@Url.Action(nameof(AvatarController.GetLayersItems))",
                     success: function (data) {
                         $($(divId).parent()).html(data);
                     },
@@ -448,53 +444,53 @@
                         window.location.href = "@(Url.Action(nameof(SignInController.Index)))"
                     }
                 })
-            .then(function () {
-                var itemIndex = $(divId).data("index");
-                totalitems = $(divId).data("count");
-                lazyLoading = (totalitems > 15) ? true : false;
-                //Prevents the repeating of the slick items on mobile
-                if (layerId == 999 && totalitems / 12 <= 1) {
-                    drag = false;
-                    infin = false;
+                .then(function () {
+                    var itemIndex = $(divId).data("index");
+                    totalitems = $(divId).data("count");
+                    lazyLoading = (totalitems > 15) ? true : false;
+                    //Prevents the repeating of the slick items on mobile
+                    if (layerId == 999 && totalitems / 12 <= 1) {
+                        drag = false;
+                        infin = false;
                     }
-                if (selectType =="Color") {
-                    slickSettings.push(SlickSettings(768,(Math.floor(itemIndex/(rowCount*8))*8), 8,false, true));
-                    slickSettings.push(SlickSettings(992,(Math.floor(itemIndex/(rowCount*10))*10), 10,false, true));
-                    slickSettings.push(SlickSettings(1200,(Math.floor(itemIndex/(rowCount*12))*12),12,false,true));
-                }
-                else{
-                    slickSettings.push(SlickSettings(500,(Math.floor(itemIndex/(rowCount*3))*3), 3,drag, false));
-                    slickSettings.push(SlickSettings(768,(Math.floor(itemIndex/(rowCount*3))*3), 3, false, true));
-                    slickSettings.push(SlickSettings(992,(Math.floor(itemIndex/(rowCount*4))*4), 4, false, true));
-                    slickSettings.push(SlickSettings(1200,(Math.floor(itemIndex/(rowCount*6))*6),6,false,true));
-                }
-                $(divId).slick({
-                    arrows: false,
-                    initialSlide: Math.floor(itemIndex / rowCount),
-                    lazyLoad: 'anticipated',
-                    mobileFirst: true,
-                    rows: rowCount,
-                    slidesPerRow: 1,
-                    slidesToShow: (lazyLoading ? 10 : 1),
-                    swipeToSlide: true,
-                    touchThreshold: 100,
-                    variableWidth: true,
-                    waitForAnimate: false,
-                    infinite: infin,
-                    responsive: slickSettings,
+                    if (selectType == "Color") {
+                        slickSettings.push(SlickSettings(768, (Math.floor(itemIndex / (rowCount * 8)) * 8), 8, false, true));
+                        slickSettings.push(SlickSettings(992, (Math.floor(itemIndex / (rowCount * 10)) * 10), 10, false, true));
+                        slickSettings.push(SlickSettings(1200, (Math.floor(itemIndex / (rowCount * 12)) * 12), 12, false, true));
+                    }
+                    else {
+                        slickSettings.push(SlickSettings(500, (Math.floor(itemIndex / (rowCount * 3)) * 3), 3, drag, false));
+                        slickSettings.push(SlickSettings(768, (Math.floor(itemIndex / (rowCount * 3)) * 3), 3, false, true));
+                        slickSettings.push(SlickSettings(992, (Math.floor(itemIndex / (rowCount * 4)) * 4), 4, false, true));
+                        slickSettings.push(SlickSettings(1200, (Math.floor(itemIndex / (rowCount * 6)) * 6), 6, false, true));
+                    }
+                    $(divId).slick({
+                        arrows: false,
+                        initialSlide: Math.floor(itemIndex / rowCount),
+                        lazyLoad: 'anticipated',
+                        mobileFirst: true,
+                        rows: rowCount,
+                        slidesPerRow: 1,
+                        slidesToShow: (lazyLoading ? 10 : 1),
+                        swipeToSlide: true,
+                        touchThreshold: 100,
+                        variableWidth: true,
+                        waitForAnimate: false,
+                        infinite: infin,
+                        responsive: slickSettings,
+                    });
+                    if (layerId == 999) {
+                        var item = GetFirstActiveSelectedItem();
+                        UpdateRemoveButtonForBundle(item);
+                    }
+                    else {
+                        prevLayerSelected = [];
+                    }
                 });
-                if (layerId == 999) {
-                    var item = GetFirstActiveSelectedItem();
-                    UpdateRemoveButtonForBundle(item);
-                }
-                else {
-                    prevLayerSelected = [];
-                }
-            });
         }
 
         //Creates the slick data
-        function SlickSettings(breakpnt,initslide, toshow,drag,arrows) {
+        function SlickSettings(breakpnt, initslide, toshow, drag, arrows) {
             return {
                 breakpoint: breakpnt,
                 settings: {
@@ -519,65 +515,66 @@
             SaveAvatar();
         });
 
-        @if (Model.SharingEnabled) {
-        // Add's the avatars selection to the share form
+        @if (Model.SharingEnabled)
+        {
+            // Add's the avatars selection to the share form
             <text>
-            $("#shareForm").on("submit", function(e) {
-                if (unsavedChanges) {
-                    @if(Context.Items[GRA.Controllers.ItemKey.GoogleAnalytics] != null){
-                        @:gtag('event', 'avatar_update');
+                $("#shareForm").on("submit", function (e) {
+                    if (unsavedChanges) {
+                        if (typeof gtag !== 'undefined') {
+                            gtag('event', 'avatar_update');
+                        }
+                        $("#shareForm").find("input")
+                            .attr("value", GetAvatarSelection())
+                            .appendTo($(this));
                     }
-                    $("#shareForm").find("input")
-                        .attr("value", GetAvatarSelection())
-                        .appendTo($(this));
-                }
-            });
+                });
             </text>
         }
 
-        // When a user removes the layer's item
-        $("#removeButton").on("click", function () {
-            unsavedChanges = true;
-            $("#saveAvatar").removeClass("btn-default");
-            $("#saveAvatar").addClass("btn-success");
-            var button = $(this);
-            var layer = CurrentSelectedLayer();
-            if (layer.data("layer") != 999) {
-                if (!$("#removeButton").hasClass("hide") && $(".avatarItems").find(".selected") != undefined
-                    && layer.data("removable") == "True") {
-                    $(".avatar-item-selector.selected").removeClass("selected");
-                    $(".avatar-color-selector.selected").removeClass("selected");
-                    layer.data("item", "");
-                    layer.data("color", "");
-                    UpdateAvatarContainer("item", "", "/", layer.data("layer"), true);
-                }
-            }
-            else {
-                var itemsLayer = GetLayerById(button.data("layer"));
-                if (itemsLayer.data("removable") == "True") {
-                    var itemId = GetLayersSelectedItemId(button.data("layer"));
-                    itemsLayer.data("item", "");
-                    var item = $("#avatarItemSelectors").find("img.avatar-item-selector[data-item='" + itemId + "']");
-                    item.removeClass("selected");
-                    var nextSelected = undefined;
-                    UpdateAvatarContainer("item", "", "/", button.data("layer"), true);
-                    prevLayerSelected.splice(0, 1);
-                    if (prevLayerSelected[0] != undefined) {
-                        nextSelected = $("#avatarItemSelectors").find("img.avatar-item-selector.selected[data-layer='" + prevLayerSelected[0] + "']");
-                        UpdateRemoveButtonForBundle(nextSelected);
+            // When a user removes the layer's item
+            $("#removeButton").on("click", function () {
+                unsavedChanges = true;
+                $("#saveAvatar").removeClass("btn-default");
+                $("#saveAvatar").addClass("btn-success");
+                var button = $(this);
+                var layer = CurrentSelectedLayer();
+                if (layer.data("layer") != 999) {
+                    if (!$("#removeButton").hasClass("hide") && $(".avatarItems").find(".selected") != undefined
+                        && layer.data("removable") == "True") {
+                        $(".avatar-item-selector.selected").removeClass("selected");
+                        $(".avatar-color-selector.selected").removeClass("selected");
+                        layer.data("item", "");
+                        layer.data("color", "");
+                        UpdateAvatarContainer("item", "", "/", layer.data("layer"), true);
                     }
-                    else {
-                        nextSelected = GetFirstActiveSelectedItem();
-                        if (nextSelected == undefined) {
-                            $("#removeButton").addClass("hide");
-                        }
-                        else {
+                }
+                else {
+                    var itemsLayer = GetLayerById(button.data("layer"));
+                    if (itemsLayer.data("removable") == "True") {
+                        var itemId = GetLayersSelectedItemId(button.data("layer"));
+                        itemsLayer.data("item", "");
+                        var item = $("#avatarItemSelectors").find("img.avatar-item-selector[data-item='" + itemId + "']");
+                        item.removeClass("selected");
+                        var nextSelected = undefined;
+                        UpdateAvatarContainer("item", "", "/", button.data("layer"), true);
+                        prevLayerSelected.splice(0, 1);
+                        if (prevLayerSelected[0] != undefined) {
+                            nextSelected = $("#avatarItemSelectors").find("img.avatar-item-selector.selected[data-layer='" + prevLayerSelected[0] + "']");
                             UpdateRemoveButtonForBundle(nextSelected);
                         }
+                        else {
+                            nextSelected = GetFirstActiveSelectedItem();
+                            if (nextSelected == undefined) {
+                                $("#removeButton").addClass("hide");
+                            }
+                            else {
+                                UpdateRemoveButtonForBundle(nextSelected);
+                            }
+                        }
                     }
                 }
-            }
-        });
+            });
 
         // Mobile if user zooms in
         $(".avatar-zoom-button").on("click", function () {
@@ -591,7 +588,7 @@
                 var scale = layer.data("zoomscale");
                 var yOffset = layer.data("zoomyoffset");
                 $(this).children().removeClass("fa-search-plus").addClass("fa-search-minus");
-                $(".xsLayer").css({ "transform": "scale(" + scale +")", "top": "" + yOffset + "px" });
+                $(".xsLayer").css({ "transform": "scale(" + scale + ")", "top": "" + yOffset + "px" });
                 xsZoom = true;
             }
         });
@@ -614,12 +611,12 @@
                     function (response) {
                         if (response.success) {
                             listItem.find('span.newBundleSpan').remove();
-                            listItem.data("beenviewed","True")
+                            listItem.data("beenviewed", "True")
                             if ($("span.newBundleSpan").length == 0) {
                                 $("#selector999").attr("src", "/content/site1/avatarbundles/icon.png");
                             }
                         }
-                });
+                    });
             }
             SetLayersSelectors("#avatarItemSelectors", 3);
         }
@@ -663,14 +660,14 @@
             // Handles the image path with the correct color
             if (itemsLayer.data("showcolorselector") == "True") {
                 if ((colorId == undefined || colorId == "")) {
-                    colorId = SelectGetFirstActiveObjectId("Color",itemsLayer);
+                    colorId = SelectGetFirstActiveObjectId("Color", itemsLayer);
                 }
                 srcStr = srcStr + "/item_" + colorId + ".png";
             }
             else {
                 srcStr = srcStr + "/item.png";
             }
-            UpdateAvatarContainer("item",itemId,srcStr,itemsLayer.data("layer"), false);
+            UpdateAvatarContainer("item", itemId, srcStr, itemsLayer.data("layer"), false);
         };
 
         // Updates the color selected and removes the old
@@ -686,11 +683,11 @@
             var itemId = layer.data("item");
             layer.data("color", colorId);
             if (itemId == "" || itemId == undefined) {
-                itemId = SelectGetFirstActiveObjectId("Item",layer);
+                itemId = SelectGetFirstActiveObjectId("Item", layer);
             }
             var srcStr = baseImagePath + "layer" + layer.data("layer") + "/item" + itemId + "/item_" + colorId + ".png";
             //updates both containers with the appropriate images
-            UpdateAvatarContainer("color",colorId,srcStr,layer.data("layer"),false);
+            UpdateAvatarContainer("color", colorId, srcStr, layer.data("layer"), false);
         };
 
         // Saves the Avatars items
@@ -701,13 +698,10 @@
                     $(".avatar-save-message").html("@SharedLocalizer[GRA.Annotations.Interface.AvatarSaved]");
                     $(".avatar-save-message").show().delay(2000).fadeOut("slow");
 
-                    @if (Context.Items[GRA.Controllers.ItemKey.GoogleAnalytics] != null){
-                        <text>
-                        if (unsavedChanges){
-                            gtag('event', 'avatar_update');
-                        }
-                        </text>
+                    if (unsavedChanges && typeof gtag !== 'undefined') {
+                        gtag('event', 'avatar_update');
                     }
+
                     SetUnsavedChanges(false);
                 }
                 else {
@@ -720,10 +714,10 @@
                 $(".avatar-save-message").html("@SharedLocalizer[GRA.Annotations.Validate.CouldNotSaveAvatar]");
                 $(".avatar-save-message").show();
             })
-            .always(function() {
-                $("#saveSpinner").addClass("hidden");
-                $("#saveAvatar").removeAttr("disabled");
-            });
+                .always(function () {
+                    $("#saveSpinner").addClass("hidden");
+                    $("#saveAvatar").removeAttr("disabled");
+                });
         }
     </script>
 }

--- a/src/GRA.Web/Views/Home/Dashboard.cshtml
+++ b/src/GRA.Web/Views/Home/Dashboard.cshtml
@@ -68,17 +68,17 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                                 @foreach (var layer in Model.AvatarElements)
                                 {
                                     <img src="~/@layer.Filename"
-                             style="z-index: @(layer.AvatarItem.AvatarLayerPosition + 1)"
-                             class="avatar-layer-dashboard" />
+                                         style="z-index: @(layer.AvatarItem.AvatarLayerPosition + 1)"
+                                         class="avatar-layer-dashboard" />
                                 }
                             </div>
                         }
                         else
                         {
                             <img src="~/content/no_avatar.png"
-                         class="img img-responsive center-block"
-                         style="width:200px;"
-                         asp-append-version="true" />
+                                 class="img img-responsive center-block"
+                                 style="width:200px;"
+                                 asp-append-version="true" />
 
                         }
                     </a>
@@ -91,14 +91,14 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                         <p style="font-size:large">@SharedLocalizer[GRA.Domain.Model.DisplayNames.MyProgress]</p>
                         <div class="progress" style="margin:0px;">
                             <div class="progress-bar progress-bar-striped @(Model.PercentComplete == 100 ? " progress-bar-success" : "") wide-tooltip"
-                         role="progressbar"
-                         aria-valuenow="@Model.PercentComplete"
-                         aria-valuemin="0"
-                         aria-valuemax="100"
-                         style="width: @Model.PercentComplete%; min-width: 10%;"
-                         title="@Model.ProgressMessage"
-                         data-toggle="tooltip"
-                         data-placement="top">
+                                 role="progressbar"
+                                 aria-valuenow="@Model.PercentComplete"
+                                 aria-valuemin="0"
+                                 aria-valuemax="100"
+                                 style="width: @Model.PercentComplete%; min-width: 10%;"
+                                 title="@Model.ProgressMessage"
+                                 data-toggle="tooltip"
+                                 data-placement="top">
                                 @Model.PercentComplete%
                             </div>
                         </div>
@@ -162,14 +162,14 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                     <p>@SharedLocalizer[GRA.Annotations.Info.OurGoalInMinutes, @Model.SiteReadingGoal]</p>
                     <div class="progress" style="margin-bottom: 0;">
                         <div class="progress-bar progress-bar-info progress-bar-striped @(Model.SiteActivityPercentComplete == 100 ? " progress-bar-success" : "") wide-tooltip"
-                         role="progressbar"
-                         aria-valuenow="@Model.SiteActivityPercentComplete"
-                         aria-valuemin="0"
-                         aria-valuemax="100"
-                         style="width: @Model.SiteActivityPercentComplete%; min-width: 10%;"
-                         title="@SharedLocalizer[GRA.Annotations.Info.OurGoalInMinutes, @Model.SiteReadingGoal]"
-                         data-toggle="tooltip"
-                         data-placement="top">
+                             role="progressbar"
+                             aria-valuenow="@Model.SiteActivityPercentComplete"
+                             aria-valuemin="0"
+                             aria-valuemax="100"
+                             style="width: @Model.SiteActivityPercentComplete%; min-width: 10%;"
+                             title="@SharedLocalizer[GRA.Annotations.Info.OurGoalInMinutes, @Model.SiteReadingGoal]"
+                             data-toggle="tooltip"
+                             data-placement="top">
                             @Model.SiteActivityPercentComplete%
                         </div>
                     </div>
@@ -201,8 +201,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                             </div>
 
                             <button type="submit"
-                            class="btn center-block btn-success btn-lg btn-spinner"
-                            button-spinner>
+                                    class="btn center-block btn-success btn-lg btn-spinner"
+                                    button-spinner>
                                 <span class="buttonText">@SharedLocalizer["I read a book!"]</span>
                             </button>
                         </form>
@@ -226,9 +226,9 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                                 <div class="col-xs-12">
                                     <span class="h4">@SharedLocalizer[GRA.Annotations.Interface.Optional]</span>
                                     <span class="fas fa-info-circle fa-sm wide-tooltip"
-                                  title="@SharedLocalizer[GRA.Annotations.Info.DashboardOptionalFields]"
-                                  data-toggle="tooltip"
-                                  data-placement="top"></span>
+                                          title="@SharedLocalizer[GRA.Annotations.Info.DashboardOptionalFields]"
+                                          data-toggle="tooltip"
+                                          data-placement="top"></span>
                                 </div>
                             </div>
 
@@ -249,8 +249,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                             </div>
 
                             <button type="submit"
-                            class="btn center-block btn-success btn-lg btn-spinner"
-                            button-spinner>
+                                    class="btn center-block btn-success btn-lg btn-spinner"
+                                    button-spinner>
                                 <span class="buttonText">@SharedLocalizer["Log {0}", SharedLocalizer[Model.ActivityDescriptionPlural]]</span>
                             </button>
                         </form>
@@ -284,8 +284,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                             </div>
 
                             <button type="submit"
-                            class="btn center-block btn-success btn-lg btn-spinner"
-                            button-spinner>
+                                    class="btn center-block btn-success btn-lg btn-spinner"
+                                    button-spinner>
                                 <span class="buttonText">@SharedLocalizer["Submit Code"]</span>
                             </button>
                         </form>
@@ -308,8 +308,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <a asp-controller="Profile"
-                   asp-action="Badges"
-                   class="lead">@SharedLocalizer["Your badges"]</a>
+                       asp-action="Badges"
+                       class="lead">@SharedLocalizer["Your badges"]</a>
                 </div>
                 <div class="panel-body">
                     <div class="row">
@@ -322,13 +322,13 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                                 {
                                     <div class="col-md-6 col-sm-12 col-xs-4 dashboard-badge">
                                         <a href="#"
-                           data-toggle="modal"
-                           data-target="#badgeDetailsModal"
-                           data-id="@userLog.Id">
+                                           data-toggle="modal"
+                                           data-target="#badgeDetailsModal"
+                                           data-id="@userLog.Id">
                                             <img alt="@userLog.BadgeAltText"
-                                 class="img-thumbnail badge-sm"
-                                 src="~/@userLog.BadgeFilename"
-                                 asp-append-version="true" />
+                                                 class="img-thumbnail badge-sm"
+                                                 src="~/@userLog.BadgeFilename"
+                                                 asp-append-version="true" />
                                         </a>
                                     </div>
                                 }
@@ -336,13 +336,13 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                                 {
                                     <div class="col-md-6 col-sm-12 col-xs-4 visible-lg visible-md visible-xs dashboard-badge">
                                         <a href="#"
-                           data-toggle="modal"
-                           data-target="#badgeDetailsModal"
-                           data-id="@userLog.Id">
+                                           data-toggle="modal"
+                                           data-target="#badgeDetailsModal"
+                                           data-id="@userLog.Id">
                                             <img alt="@userLog.BadgeAltText"
-                                 class="img-thumbnail badge-sm"
-                                 src="~/@userLog.BadgeFilename"
-                                 asp-append-version="true" />
+                                                 class="img-thumbnail badge-sm"
+                                                 src="~/@userLog.BadgeFilename"
+                                                 asp-append-version="true" />
                                         </a>
                                     </div>
                                 }
@@ -351,8 +351,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                                 {
                                     <div class="col-xs-12 visible-lg visible-md visible-xs">
                                         <a asp-controller="Profile"
-                           asp-action="Badges"
-                           class="lead">@SharedLocalizer["See more of your badges"]</a>
+                                           asp-action="Badges"
+                                           class="lead">@SharedLocalizer["See more of your badges"]</a>
                                     </div>
                                     break;
                                 }
@@ -361,8 +361,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                             {
                                 <div class="col-xs-12 visible-sm">
                                     <a asp-controller="Profile"
-                           asp-action="Badges"
-                           class="lead">@SharedLocalizer["See more of your badges"]</a>
+                                       asp-action="Badges"
+                                       class="lead">@SharedLocalizer["See more of your badges"]</a>
                                 </div>
                             }
                         }
@@ -379,10 +379,10 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                     <div class="panel-body text-center">
                         <div class="row">
                             <button type="button"
-                            id="viewDailyImage"
-                            class="btn btn-primary"
-                            style="margin:0 8px; white-space: normal; font-size: large;"
-                            data-src="@Url.Content($"~/{Model.DailyImagePath}")">
+                                    id="viewDailyImage"
+                                    class="btn btn-primary"
+                                    style="margin:0 8px; white-space: normal; font-size: large;"
+                                    data-src="@Url.Content($"~/{Model.DailyImagePath}")">
                                 @Model.DailyImageMessage
                             </button>
                         </div>
@@ -401,8 +401,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <a asp-controller="@EventsController.Name"
-                   asp-action="@nameof(EventsController.StreamingEvents)"
-                   class="lead">@SharedLocalizer[GRA.Annotations.Interface.StreamingEvents]</a>
+                       asp-action="@nameof(EventsController.StreamingEvents)"
+                       class="lead">@SharedLocalizer[GRA.Annotations.Interface.StreamingEvents]</a>
                 </div>
                 <ul class="list-group">
                     @foreach (var stream in Model.UpcomingStreams)
@@ -465,10 +465,10 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                         {
                             <div>
                                 <a href="#"
-                           class="gra-carousel-link"
-                           data-itemid="@item.Id"
-                           data-title="@item.Title"
-                           data-img="@item.ImageUrl">
+                                   class="gra-carousel-link"
+                                   data-itemid="@item.Id"
+                                   data-title="@item.Title"
+                                   data-img="@item.ImageUrl">
                                     <img src="@item.ImageUrl" />
                                     <p>@item.Title</p>
                                 </a>
@@ -488,16 +488,16 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                 <div class="modal-content">
                     <div class="modal-body">
                         <span class="frame-close fa-stack fa-lg gra-close-stack gra-close-stack-absolute"
-                          data-dismiss="modal"
-                          alt="@SharedLocalizer[GRA.Annotations.Interface.CloseDialog]"
-                          role="button">
+                              data-dismiss="modal"
+                              alt="@SharedLocalizer[GRA.Annotations.Interface.CloseDialog]"
+                              role="button">
                             <span class="fas fa-circle fa-stack-2x fa-inverse"></span>
                             <span class="fas fa-times-circle fa-stack-1x fa-lg gra-close-times"></span>
                         </span>
                         <div class="row">
                             <div class="col-xs-12 col-sm-3 ">
                                 <img id="graCarouselModalImage"
-                                 class="center-block gra-carousel-modal-image" />
+                                     class="center-block gra-carousel-modal-image" />
                             </div>
                             <div class="col-xs-12 col-sm-9">
                                 <p style="font-size: 2rem; font-weight: bold;" id="graCarouselModalHeader"></p>
@@ -514,19 +514,19 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
 {
     <div class="row">
         <div class="modal fade"
-         id="dailyImageModal"
-         style="text-align:center;"
-         tabindex="-1"
-         role="dialog"
-         aria-labelledby="dailyImageModalLabel">
+             id="dailyImageModal"
+             style="text-align:center;"
+             tabindex="-1"
+             role="dialog"
+             aria-labelledby="dailyImageModalLabel">
             <div class="modal-dialog @(Model.DailyImageLarge ? "modal-lg" : "")"
-             style="display: inline-block;"
-             role="document">
+                 style="display: inline-block;"
+                 role="document">
                 <div class="modal-content">
                     <span class="frame-close fa-stack fa-lg gra-close-stack gra-close-stack-absolute"
-                      data-dismiss="modal"
-                      alt="@SharedLocalizer[GRA.Annotations.Interface.CloseDialog]"
-                      role="button">
+                          data-dismiss="modal"
+                          alt="@SharedLocalizer[GRA.Annotations.Interface.CloseDialog]"
+                          role="button">
                         <span class="fas fa-circle fa-stack-2x fa-inverse"></span>
                         <span class="fas fa-times-circle fa-stack-1x fa-lg gra-close-times"></span>
                     </span>
@@ -541,17 +541,17 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
 @if (Model.UserLogs?.Count() > 0)
 {
     <div class="modal fade"
-     id="badgeDetailsModal"
-     tabindex="-1"
-     role="dialog"
-     aria-labelledby="badgeDetailsModalLabel">
+         id="badgeDetailsModal"
+         tabindex="-1"
+         role="dialog"
+         aria-labelledby="badgeDetailsModalLabel">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button"
-                        class="close"
-                        data-dismiss="modal"
-                        aria-label="Close">
+                            class="close"
+                            data-dismiss="modal"
+                            aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
                     <h1 class="h4 modal-title">
@@ -562,8 +562,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                 </div>
                 <div class="modal-footer">
                     <button type="button"
-                        class="btn btn-default"
-                        data-dismiss="modal">
+                            class="btn btn-default"
+                            data-dismiss="modal">
                         @SharedLocalizer[GRA.Annotations.Interface.Back]
                     </button>
                 </div>
@@ -577,49 +577,70 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
         {
             <text>
                 $("#viewDailyImage").on("click", function () {
-                    var src = $(this).data("src");
+                    let src = $(this).data("src");
                     $(".daily-image").attr("src", src);
                     $("#dailyImageModal").modal().show();
-                    gtag('event', 'view_daily_tip', {
-                        'event_category': 'image',
-                        'event_label': src
-                    });
+                    if (typeof gtag !== 'undefined') {
+                        gtag('event', 'view_daily_tip', {
+                            'source_page': 'dashboard',
+                            'event_category': 'image',
+                            'event_label': @Model.Day
+                        });
+                    }
                 });
             </text>
         }
         @if (Context.Items[GRA.Controllers.ItemKey.GoogleAnalytics] != null && Model.UserJoined)
         {
             <text>
+                                        if (typeof gtag !== 'undefined') {
                 gtag('event', 'sign_up', {
                     'First Time Participant': '@Model.FirstTimeParticipant',
                     'Program Name': '@Model.ProgramName',
                 });
+            }
             </text>
         }
     </script>
     @if (Model.Carousel != null)
     {
         <script>
-            $(".gra-carousel-link").on("click", function (event) {
-                event.preventDefault();
-                event.stopPropagation();
-                event.stopImmediatePropagation();
-                $("#graCarouselModalContent").html("<div class=\"gra-carousel-spinner\"><span class=\"fas fa-spinner fa-3x fa-spin\"></span></div>");
-                var id = $(this).data("itemid");
+                $(".gra-carousel-link").on("click", function (event) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    event.stopImmediatePropagation();
+                    $("#graCarouselModalContent").html("<div class=\"gra-carousel-spinner\"><span class=\"fas fa-spinner fa-3x fa-spin\"></span></div>");
+                    let id = $(this).data("itemid");
+                    let title = $(this).data("title");
 
-                var jqXHR = $.get("@Url.Action("GetCarouselDescription", "Home")/" + id,
-                    function (data) {
-                        $("#graCarouselModalContent").html(data);
+                    if (typeof gtag !== 'undefined') {
+                        gtag('event', 'select_content', {
+                            'content_type': 'dashboard carousel',
+                            'content_id': title
+                        });
                     }
-                ).fail(function () {
-                    $("#graCarouselModalContent").html("Could not find details for this item, sorry!");
+
+                    $.get("@Url.Action("GetCarouselDescription", "Home")/" + id,
+                        function (data) {
+                            $("#graCarouselModalContent").html(data);
+                        }
+                    ).fail(function () {
+                        $("#graCarouselModalContent").html("Could not find details for this item, sorry!");
+                    });
+
+                    $("#graCarouselModalHeader").text($(this).data("title"));
+                    $("#graCarouselModalImage").attr("src", $(this).data("img"));
+
+                    $("#graCarouselModal").modal().show();
                 });
-
-                $("#graCarouselModalHeader").text($(this).data("title"));
-                $("#graCarouselModalImage").attr("src", $(this).data("img"));
-
-                $("#graCarouselModal").modal().show();
-            });
+            if (typeof gtag !== 'undefined') {
+                $(".gra-carousel").on("beforeChange", function (e, s, c, n) {
+                    gtag('event', 'select_content', {
+                        'content_type': 'dashboard carousel',
+                        'content_id': 'next or previous'
+                    });
+                });
+            }
         </script>
         <link rel="stylesheet" type="text/css" href="/css/slick.min.css" />
         <script type="text/javascript" src="/js/slick.min.js"></script>
@@ -628,11 +649,11 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
     {
         <script>
             $("#badgeDetailsModal").on("show.bs.modal", function (event) {
-                var button = $(event.relatedTarget);
-                var id = button.data("id");
-                var modal = $(this);
+                let button = $(event.relatedTarget);
+                let id = button.data("id");
+                let modal = $(this);
 
-                var modalBody = modal.find(".modal-body");
+                let modalBody = modal.find(".modal-body");
                 modalBody.html("<div class=\"text-center\" style=\"width: 100%;\"><span class=\"fas fa-spinner fa-2x fa-pulse\"></span></div>");
 
                 $.get("@Url.Action(nameof(ProfileController.GetUserBadgeInfo), ProfileController.Name)",

--- a/src/GRA.Web/Views/Home/Dashboard.es.cshtml
+++ b/src/GRA.Web/Views/Home/Dashboard.es.cshtml
@@ -68,17 +68,17 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                                 @foreach (var layer in Model.AvatarElements)
                                 {
                                     <img src="~/@layer.Filename"
-                             style="z-index: @(layer.AvatarItem.AvatarLayerPosition + 1)"
-                             class="avatar-layer-dashboard" />
+                                         style="z-index: @(layer.AvatarItem.AvatarLayerPosition + 1)"
+                                         class="avatar-layer-dashboard" />
                                 }
                             </div>
                         }
                         else
                         {
                             <img src="~/content/no_avatar.png"
-                         class="img img-responsive center-block"
-                         style="width:200px;"
-                         asp-append-version="true" />
+                                 class="img img-responsive center-block"
+                                 style="width:200px;"
+                                 asp-append-version="true" />
 
                         }
                     </a>
@@ -91,14 +91,14 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                         <p style="font-size:large">@SharedLocalizer[GRA.Domain.Model.DisplayNames.MyProgress]</p>
                         <div class="progress" style="margin:0px;">
                             <div class="progress-bar progress-bar-striped @(Model.PercentComplete == 100 ? " progress-bar-success" : "") wide-tooltip"
-                         role="progressbar"
-                         aria-valuenow="@Model.PercentComplete"
-                         aria-valuemin="0"
-                         aria-valuemax="100"
-                         style="width: @Model.PercentComplete%; min-width: 10%;"
-                         title="@Model.ProgressMessage"
-                         data-toggle="tooltip"
-                         data-placement="top">
+                                 role="progressbar"
+                                 aria-valuenow="@Model.PercentComplete"
+                                 aria-valuemin="0"
+                                 aria-valuemax="100"
+                                 style="width: @Model.PercentComplete%; min-width: 10%;"
+                                 title="@Model.ProgressMessage"
+                                 data-toggle="tooltip"
+                                 data-placement="top">
                                 @Model.PercentComplete%
                             </div>
                         </div>
@@ -162,14 +162,14 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                     <p>@SharedLocalizer[GRA.Annotations.Info.OurGoalInMinutes, @Model.SiteReadingGoal]</p>
                     <div class="progress" style="margin-bottom: 0;">
                         <div class="progress-bar progress-bar-info progress-bar-striped @(Model.SiteActivityPercentComplete == 100 ? " progress-bar-success" : "") wide-tooltip"
-                         role="progressbar"
-                         aria-valuenow="@Model.SiteActivityPercentComplete"
-                         aria-valuemin="0"
-                         aria-valuemax="100"
-                         style="width: @Model.SiteActivityPercentComplete%; min-width: 10%;"
-                         title="@SharedLocalizer[GRA.Annotations.Info.OurGoalInMinutes, @Model.SiteReadingGoal]"
-                         data-toggle="tooltip"
-                         data-placement="top">
+                             role="progressbar"
+                             aria-valuenow="@Model.SiteActivityPercentComplete"
+                             aria-valuemin="0"
+                             aria-valuemax="100"
+                             style="width: @Model.SiteActivityPercentComplete%; min-width: 10%;"
+                             title="@SharedLocalizer[GRA.Annotations.Info.OurGoalInMinutes, @Model.SiteReadingGoal]"
+                             data-toggle="tooltip"
+                             data-placement="top">
                             @Model.SiteActivityPercentComplete%
                         </div>
                     </div>
@@ -201,8 +201,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                             </div>
 
                             <button type="submit"
-                            class="btn center-block btn-success btn-lg btn-spinner"
-                            button-spinner>
+                                    class="btn center-block btn-success btn-lg btn-spinner"
+                                    button-spinner>
                                 <span class="buttonText">@SharedLocalizer["I read a book!"]</span>
                             </button>
                         </form>
@@ -226,9 +226,9 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                                 <div class="col-xs-12">
                                     <span class="h4">@SharedLocalizer[GRA.Annotations.Interface.Optional]</span>
                                     <span class="fas fa-info-circle fa-sm wide-tooltip"
-                                  title="@SharedLocalizer[GRA.Annotations.Info.DashboardOptionalFields]"
-                                  data-toggle="tooltip"
-                                  data-placement="top"></span>
+                                          title="@SharedLocalizer[GRA.Annotations.Info.DashboardOptionalFields]"
+                                          data-toggle="tooltip"
+                                          data-placement="top"></span>
                                 </div>
                             </div>
 
@@ -249,8 +249,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                             </div>
 
                             <button type="submit"
-                            class="btn center-block btn-success btn-lg btn-spinner"
-                            button-spinner>
+                                    class="btn center-block btn-success btn-lg btn-spinner"
+                                    button-spinner>
                                 <span class="buttonText">@SharedLocalizer["Log {0}", SharedLocalizer[Model.ActivityDescriptionPlural]]</span>
                             </button>
                         </form>
@@ -284,8 +284,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                             </div>
 
                             <button type="submit"
-                            class="btn center-block btn-success btn-lg btn-spinner"
-                            button-spinner>
+                                    class="btn center-block btn-success btn-lg btn-spinner"
+                                    button-spinner>
                                 <span class="buttonText">@SharedLocalizer["Submit Code"]</span>
                             </button>
                         </form>
@@ -308,8 +308,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <a asp-controller="Profile"
-                   asp-action="Badges"
-                   class="lead">@SharedLocalizer["Your badges"]</a>
+                       asp-action="Badges"
+                       class="lead">@SharedLocalizer["Your badges"]</a>
                 </div>
                 <div class="panel-body">
                     <div class="row">
@@ -322,13 +322,13 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                                 {
                                     <div class="col-md-6 col-sm-12 col-xs-4 dashboard-badge">
                                         <a href="#"
-                           data-toggle="modal"
-                           data-target="#badgeDetailsModal"
-                           data-id="@userLog.Id">
+                                           data-toggle="modal"
+                                           data-target="#badgeDetailsModal"
+                                           data-id="@userLog.Id">
                                             <img alt="@userLog.BadgeAltText"
-                                 class="img-thumbnail badge-sm"
-                                 src="~/@userLog.BadgeFilename"
-                                 asp-append-version="true" />
+                                                 class="img-thumbnail badge-sm"
+                                                 src="~/@userLog.BadgeFilename"
+                                                 asp-append-version="true" />
                                         </a>
                                     </div>
                                 }
@@ -336,13 +336,13 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                                 {
                                     <div class="col-md-6 col-sm-12 col-xs-4 visible-lg visible-md visible-xs dashboard-badge">
                                         <a href="#"
-                           data-toggle="modal"
-                           data-target="#badgeDetailsModal"
-                           data-id="@userLog.Id">
+                                           data-toggle="modal"
+                                           data-target="#badgeDetailsModal"
+                                           data-id="@userLog.Id">
                                             <img alt="@userLog.BadgeAltText"
-                                 class="img-thumbnail badge-sm"
-                                 src="~/@userLog.BadgeFilename"
-                                 asp-append-version="true" />
+                                                 class="img-thumbnail badge-sm"
+                                                 src="~/@userLog.BadgeFilename"
+                                                 asp-append-version="true" />
                                         </a>
                                     </div>
                                 }
@@ -351,8 +351,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                                 {
                                     <div class="col-xs-12 visible-lg visible-md visible-xs">
                                         <a asp-controller="Profile"
-                           asp-action="Badges"
-                           class="lead">@SharedLocalizer["See more of your badges"]</a>
+                                           asp-action="Badges"
+                                           class="lead">@SharedLocalizer["See more of your badges"]</a>
                                     </div>
                                     break;
                                 }
@@ -361,8 +361,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                             {
                                 <div class="col-xs-12 visible-sm">
                                     <a asp-controller="Profile"
-                           asp-action="Badges"
-                           class="lead">@SharedLocalizer["See more of your badges"]</a>
+                                       asp-action="Badges"
+                                       class="lead">@SharedLocalizer["See more of your badges"]</a>
                                 </div>
                             }
                         }
@@ -379,10 +379,10 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                     <div class="panel-body text-center">
                         <div class="row">
                             <button type="button"
-                            id="viewDailyImage"
-                            class="btn btn-primary"
-                            style="margin:0 8px; white-space: normal; font-size: large;"
-                            data-src="@Url.Content($"~/{Model.DailyImagePath}")">
+                                    id="viewDailyImage"
+                                    class="btn btn-primary"
+                                    style="margin:0 8px; white-space: normal; font-size: large;"
+                                    data-src="@Url.Content($"~/{Model.DailyImagePath}")">
                                 @Model.DailyImageMessage
                             </button>
                         </div>
@@ -401,8 +401,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <a asp-controller="@EventsController.Name"
-                   asp-action="@nameof(EventsController.StreamingEvents)"
-                   class="lead">@SharedLocalizer[GRA.Annotations.Interface.StreamingEvents]</a>
+                       asp-action="@nameof(EventsController.StreamingEvents)"
+                       class="lead">@SharedLocalizer[GRA.Annotations.Interface.StreamingEvents]</a>
                 </div>
                 <ul class="list-group">
                     @foreach (var stream in Model.UpcomingStreams)
@@ -465,10 +465,10 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                         {
                             <div>
                                 <a href="#"
-                           class="gra-carousel-link"
-                           data-itemid="@item.Id"
-                           data-title="@item.Title"
-                           data-img="@item.ImageUrl">
+                                   class="gra-carousel-link"
+                                   data-itemid="@item.Id"
+                                   data-title="@item.Title"
+                                   data-img="@item.ImageUrl">
                                     <img src="@item.ImageUrl" />
                                     <p>@item.Title</p>
                                 </a>
@@ -488,16 +488,16 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                 <div class="modal-content">
                     <div class="modal-body">
                         <span class="frame-close fa-stack fa-lg gra-close-stack gra-close-stack-absolute"
-                          data-dismiss="modal"
-                          alt="@SharedLocalizer[GRA.Annotations.Interface.CloseDialog]"
-                          role="button">
+                              data-dismiss="modal"
+                              alt="@SharedLocalizer[GRA.Annotations.Interface.CloseDialog]"
+                              role="button">
                             <span class="fas fa-circle fa-stack-2x fa-inverse"></span>
                             <span class="fas fa-times-circle fa-stack-1x fa-lg gra-close-times"></span>
                         </span>
                         <div class="row">
                             <div class="col-xs-12 col-sm-3 ">
                                 <img id="graCarouselModalImage"
-                                 class="center-block gra-carousel-modal-image" />
+                                     class="center-block gra-carousel-modal-image" />
                             </div>
                             <div class="col-xs-12 col-sm-9">
                                 <p style="font-size: 2rem; font-weight: bold;" id="graCarouselModalHeader"></p>
@@ -514,19 +514,19 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
 {
     <div class="row">
         <div class="modal fade"
-         id="dailyImageModal"
-         style="text-align:center;"
-         tabindex="-1"
-         role="dialog"
-         aria-labelledby="dailyImageModalLabel">
+             id="dailyImageModal"
+             style="text-align:center;"
+             tabindex="-1"
+             role="dialog"
+             aria-labelledby="dailyImageModalLabel">
             <div class="modal-dialog @(Model.DailyImageLarge ? "modal-lg" : "")"
-             style="display: inline-block;"
-             role="document">
+                 style="display: inline-block;"
+                 role="document">
                 <div class="modal-content">
                     <span class="frame-close fa-stack fa-lg gra-close-stack gra-close-stack-absolute"
-                      data-dismiss="modal"
-                      alt="@SharedLocalizer[GRA.Annotations.Interface.CloseDialog]"
-                      role="button">
+                          data-dismiss="modal"
+                          alt="@SharedLocalizer[GRA.Annotations.Interface.CloseDialog]"
+                          role="button">
                         <span class="fas fa-circle fa-stack-2x fa-inverse"></span>
                         <span class="fas fa-times-circle fa-stack-1x fa-lg gra-close-times"></span>
                     </span>
@@ -541,17 +541,17 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
 @if (Model.UserLogs?.Count() > 0)
 {
     <div class="modal fade"
-     id="badgeDetailsModal"
-     tabindex="-1"
-     role="dialog"
-     aria-labelledby="badgeDetailsModalLabel">
+         id="badgeDetailsModal"
+         tabindex="-1"
+         role="dialog"
+         aria-labelledby="badgeDetailsModalLabel">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button"
-                        class="close"
-                        data-dismiss="modal"
-                        aria-label="Close">
+                            class="close"
+                            data-dismiss="modal"
+                            aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>
                     <h1 class="h4 modal-title">
@@ -562,8 +562,8 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
                 </div>
                 <div class="modal-footer">
                     <button type="button"
-                        class="btn btn-default"
-                        data-dismiss="modal">
+                            class="btn btn-default"
+                            data-dismiss="modal">
                         @SharedLocalizer[GRA.Annotations.Interface.Back]
                     </button>
                 </div>
@@ -577,49 +577,70 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
         {
             <text>
                 $("#viewDailyImage").on("click", function () {
-                    var src = $(this).data("src");
+                    let src = $(this).data("src");
                     $(".daily-image").attr("src", src);
                     $("#dailyImageModal").modal().show();
-                    gtag('event', 'view_daily_tip', {
-                        'event_category': 'image',
-                        'event_label': src
-                    });
+                    if (typeof gtag !== 'undefined') {
+                        gtag('event', 'view_daily_tip', {
+                            'source_page': 'dashboard',
+                            'event_category': 'image',
+                            'event_label': @Model.Day
+                                    });
+                    }
                 });
             </text>
         }
         @if (Context.Items[GRA.Controllers.ItemKey.GoogleAnalytics] != null && Model.UserJoined)
         {
             <text>
+                                                    if (typeof gtag !== 'undefined') {
                 gtag('event', 'sign_up', {
                     'First Time Participant': '@Model.FirstTimeParticipant',
                     'Program Name': '@Model.ProgramName',
                 });
+            }
             </text>
         }
     </script>
     @if (Model.Carousel != null)
     {
         <script>
-            $(".gra-carousel-link").on("click", function (event) {
-                event.preventDefault();
-                event.stopPropagation();
-                event.stopImmediatePropagation();
-                $("#graCarouselModalContent").html("<div class=\"gra-carousel-spinner\"><span class=\"fas fa-spinner fa-3x fa-spin\"></span></div>");
-                var id = $(this).data("itemid");
+                $(".gra-carousel-link").on("click", function (event) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    event.stopImmediatePropagation();
+                    $("#graCarouselModalContent").html("<div class=\"gra-carousel-spinner\"><span class=\"fas fa-spinner fa-3x fa-spin\"></span></div>");
+                    let id = $(this).data("itemid");
+                    let title = $(this).data("title");
 
-                var jqXHR = $.get("@Url.Action("GetCarouselDescription", "Home")/" + id,
-                    function (data) {
-                        $("#graCarouselModalContent").html(data);
+                    if (typeof gtag !== 'undefined') {
+                        gtag('event', 'select_content', {
+                            'content_type': 'dashboard carousel',
+                            'content_id': title
+                        });
                     }
-                ).fail(function () {
-                    $("#graCarouselModalContent").html("Could not find details for this item, sorry!");
+
+                    $.get("@Url.Action("GetCarouselDescription", "Home")/" + id,
+                        function (data) {
+                            $("#graCarouselModalContent").html(data);
+                        }
+                    ).fail(function () {
+                        $("#graCarouselModalContent").html("Could not find details for this item, sorry!");
+                    });
+
+                    $("#graCarouselModalHeader").text($(this).data("title"));
+                    $("#graCarouselModalImage").attr("src", $(this).data("img"));
+
+                    $("#graCarouselModal").modal().show();
                 });
-
-                $("#graCarouselModalHeader").text($(this).data("title"));
-                $("#graCarouselModalImage").attr("src", $(this).data("img"));
-
-                $("#graCarouselModal").modal().show();
-            });
+            if (typeof gtag !== 'undefined') {
+                $(".gra-carousel").on("beforeChange", function (e, s, c, n) {
+                    gtag('event', 'select_content', {
+                        'content_type': 'dashboard carousel',
+                        'content_id': 'next or previous'
+                    });
+                });
+            }
         </script>
         <link rel="stylesheet" type="text/css" href="/css/slick.min.css" />
         <script type="text/javascript" src="/js/slick.min.js"></script>
@@ -628,11 +649,11 @@ else if (Model.User.VendorOrderStatus > VendorOrderStatus.Pending && Model.User.
     {
         <script>
             $("#badgeDetailsModal").on("show.bs.modal", function (event) {
-                var button = $(event.relatedTarget);
-                var id = button.data("id");
-                var modal = $(this);
+                let button = $(event.relatedTarget);
+                let id = button.data("id");
+                let modal = $(this);
 
-                var modalBody = modal.find(".modal-body");
+                let modalBody = modal.find(".modal-body");
                 modalBody.html("<div class=\"text-center\" style=\"width: 100%;\"><span class=\"fas fa-spinner fa-2x fa-pulse\"></span></div>");
 
                 $.get("@Url.Action(nameof(ProfileController.GetUserBadgeInfo), ProfileController.Name)",

--- a/src/GRA.Web/Views/Profile/Household.cshtml
+++ b/src/GRA.Web/Views/Profile/Household.cshtml
@@ -237,7 +237,8 @@
                                                                 class="btn btn-primary btn-xs viewDailyImage"
                                                                 style="display: inline-block;vertical-align:top;"
                                                                 data-src="@Url.Content($"~/{Model.DailyImageDictionary[Model.Head.ProgramId].DailyImagePath}")"
-                                                                data-large="@Model.DailyImageDictionary[Model.Head.ProgramId].IsLarge">
+                                                                data-large="@Model.DailyImageDictionary[Model.Head.ProgramId].IsLarge"
+                                                                data-day="@Model.DailyImageDictionary[Model.Head.ProgramId].Day">
                                                             @Model.DailyImageDictionary[Model.Head.ProgramId].DailyImageMessage
                                                         </button>
                                                     }
@@ -389,7 +390,8 @@
                                                                     class="btn btn-primary btn-xs viewDailyImage"
                                                                     style="display: inline-block;vertical-align:top;"
                                                                     data-src="@Url.Content($"~/{Model.DailyImageDictionary[user.ProgramId].DailyImagePath}")"
-                                                                    data-large="@Model.DailyImageDictionary[user.ProgramId].IsLarge.ToString().ToLower()">
+                                                                    data-large="@Model.DailyImageDictionary[user.ProgramId].IsLarge.ToString().ToLower()"
+                                                                    data-day="@Model.DailyImageDictionary[user.ProgramId].Day">
                                                                 @Model.DailyImageDictionary[user.ProgramId].DailyImageMessage
                                                             </button>
                                                         }
@@ -658,14 +660,22 @@
         };
 
         $(".viewDailyImage").on("click", function () {
-            var src = $(this).data("src");
-            var isLarge = $(this).data("large");
+            let src = $(this).data("src");
+            let isLarge = $(this).data("large");
+            let day = $(this).data("day");
             $(".daily-image").attr("src", src);
             if (isLarge) {
                 $("#dailyImageModalDialog").addClass("modal-lg")
             }
             else {
                 $("#dailyImageModalDialog").removeClass("modal-lg")
+            }
+            if (typeof gtag !== 'undefined') {
+                gtag('event', 'view_daily_tip', {
+                    'source_page': 'household',
+                    'event_category': 'image',
+                    'event_label': day
+                });
             }
             $("#dailyImageModal").modal().show();
         });

--- a/src/GRA.Web/Views/Shared/_Layout.cshtml
+++ b/src/GRA.Web/Views/Shared/_Layout.cshtml
@@ -70,7 +70,12 @@
 
             @if (Context.Items[GRA.Controllers.ItemKey.SignedIn] != null)
             {
-                @:gtag('event', 'login');
+                <text>
+                if (typeof gtag !== 'undefined')
+                {
+                    gtag('event', 'login');
+                }
+                </text>
             }
         </script>
     }
@@ -251,9 +256,9 @@
     <script src="/js/main.min.js"></script>
     @RenderSection("scripts", required: false)
     <script>
-            $(function () {
-                $('[data-toggle="tooltip"]').tooltip()
-            })
+        $(function () {
+            $('[data-toggle="tooltip"]').tooltip()
+        })
         @if (Context.Items[GRA.Controllers.ItemKey.NotificationsModal] != null)
         {
             @:$('#notificationsModal').modal('show');


### PR DESCRIPTION
- Properly skip calls to `gtag` if the JavaScript is not loaded
- Send Analytics events for dashboard carousel interactions