### PR TITLE
Add the ability for triggers to be activated by a low point threshold

### DIFF
--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DocumentFormat.OpenXml.EMMA;
 using GRA.Controllers.ViewModel.MissionControl.Triggers;
 using GRA.Controllers.ViewModel.Shared;
 using GRA.Domain.Model;
@@ -575,6 +576,11 @@ namespace GRA.Controllers.MissionControl
             {
                 ModelState.AddModelError("Trigger.AwardPoints",
                     $"You may award up to {model.MaxPointLimit} points.");
+            }
+            if (model.Trigger.Points < model.MinAllowedPoints)
+            {
+                ModelState.AddModelError("Trigger.Points",
+                    $"Trigger must have at least {model.MinAllowedPoints} points.");
             }
             if (!string.IsNullOrWhiteSpace(model.BadgeRequiredList))
             {

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using DocumentFormat.OpenXml.EMMA;
 using GRA.Controllers.ViewModel.MissionControl.Triggers;
 using GRA.Controllers.ViewModel.Shared;
 using GRA.Domain.Model;

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -904,10 +904,20 @@ namespace GRA.Controllers.MissionControl
             bool? mine,
             int? programId,
             bool? lowPoints,
+            bool? hideLowPoint,
             int page = 1)
         {
             var filter = new TriggerFilter(page);
+            var (lowPointThresholdSet, lowPointThreshold) = await _siteLookupService.GetSiteSettingIntAsync(GetCurrentSiteId(), SiteSettingKey.Triggers.LowPointThreshold);
 
+            if (lowPointThreshold == 0)
+            {
+                hideLowPoint = true;
+            }
+            else
+            {
+                hideLowPoint = false;
+            }
             if (!string.IsNullOrWhiteSpace(search))
             {
                 filter.Search = search;
@@ -919,7 +929,6 @@ namespace GRA.Controllers.MissionControl
             }
             else if (lowPoints == true)
             {
-                var (lowPointThresholdSet, lowPointThreshold) = await _siteLookupService.GetSiteSettingIntAsync(GetCurrentSiteId(), SiteSettingKey.Triggers.LowPointThreshold);
                 filter.PointsBelowOrEqual = lowPointThreshold;
             }
             else if (branchId.HasValue)
@@ -985,8 +994,10 @@ namespace GRA.Controllers.MissionControl
                 BranchId = branchId,
                 ProgramId = programId,
                 Mine = mine,
+                HideLowPoint = hideLowPoint,
                 LowPoints = lowPoints,
                 SystemList = systemList,
+
                 ProgramList = await _siteService.GetProgramList()
             };
             if (mine == true)

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -861,7 +861,7 @@ namespace GRA.Controllers.MissionControl
             else if (lowPoints == true)
             {
                 filter.PointsBelowOrEqual = await _triggerService.GetLowPointThresholdAsync(GetCurrentSiteId());
-                }
+            }
             else if (branchId.HasValue)
             {
                 filter.BranchIds = new List<int> { branchId.Value };

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -841,8 +841,9 @@ namespace GRA.Controllers.MissionControl
         public async Task<IActionResult> Index(string search,
             int? systemId,
             int? branchId,
-            bool? mine, int?
-            programId,
+            bool? mine,
+            bool? lowPoint,
+            int? programId,
             int page = 1)
         {
             var filter = new TriggerFilter(page);
@@ -855,6 +856,10 @@ namespace GRA.Controllers.MissionControl
             if (mine == true)
             {
                 filter.UserIds = new List<int> { GetId(ClaimType.UserId) };
+            }
+            else if (lowPoint == true)
+            {
+
             }
             else if (branchId.HasValue)
             {
@@ -919,6 +924,7 @@ namespace GRA.Controllers.MissionControl
                 BranchId = branchId,
                 ProgramId = programId,
                 Mine = mine,
+                LowPoints = lowPoint,
                 SystemList = systemList,
                 ProgramList = await _siteService.GetProgramList()
             };
@@ -928,6 +934,10 @@ namespace GRA.Controllers.MissionControl
                         .OrderByDescending(_ => _.Id == GetId(ClaimType.BranchId))
                         .ThenBy(_ => _.Name);
                 viewModel.ActiveNav = "Mine";
+            }
+            else if (lowPoint == true)
+            {
+
             }
             else if (branchId.HasValue)
             {

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -10,6 +10,7 @@ using GRA.Controllers.ViewModel.Shared;
 using GRA.Domain.Model;
 using GRA.Domain.Model.Filters;
 using GRA.Domain.Service;
+using GRA.SiteSettingKey;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -263,6 +264,7 @@ namespace GRA.Controllers.MissionControl
                             .ToLowerInvariant();
                         model.Trigger.BadgeIds = new List<int>();
                         model.Trigger.ChallengeIds = new List<int>();
+                        model.LowPointThreshold = null;
                     }
                     else
                     {
@@ -324,7 +326,7 @@ namespace GRA.Controllers.MissionControl
                         model.Trigger.AwardAttachmentId = attachment.Id;
                     }
                     var trigger = await _triggerService.AddAsync(model.Trigger);
-                    if (model.LowPointThreshold >= trigger.Points)
+                    if (model.LowPointThreshold != null && model.LowPointThreshold >= trigger.Points)
                     {
                         ShowAlertWarning($"Trigger is a low point trigger.");
                     }
@@ -783,7 +785,7 @@ namespace GRA.Controllers.MissionControl
                         model.Trigger.AwardAttachmentId = null;
                     }
 
-                    if (model.LowPointThreshold >= model.Trigger.Points)
+                    if (model.LowPointThreshold != null && model.LowPointThreshold >= model.Trigger.Points)
                     {
                         ShowAlertWarning($"Trigger is a low point trigger.");
                     }

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -126,12 +126,18 @@ namespace GRA.Controllers.MissionControl
             model.LowPointThreshold = await _triggerService.GetLowPointThresholdAsync(GetCurrentSiteId());
             model.MaxPointLimit = await _triggerService
                 .GetMaximumAllowedPointsAsync(GetCurrentSiteId());
+            model.MinAllowedPoints = await _triggerService.GetMinimumPointsAsync(GetCurrentSiteId());
             if (!model.IgnorePointLimits
                 && model.MaxPointLimit.HasValue
                 && model.Trigger.AwardPoints > model.MaxPointLimit)
             {
                 ModelState.AddModelError("Trigger.AwardPoints",
                     $"You may award up to {model.MaxPointLimit} points.");
+            }
+            if(model.Trigger.Points < model.MinAllowedPoints)
+            {
+                ModelState.AddModelError("Trigger.Points",
+                    $"Trigger must have at least {model.MinAllowedPoints} points.");
             }
             if (!string.IsNullOrWhiteSpace(model.BadgeRequiredList))
             {

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -97,11 +97,6 @@ namespace GRA.Controllers.MissionControl
                 viewModel.MaxPointsMessage = $"(Up to {viewModel.MaxPointLimit.Value} points)";
             }
 
-            if (viewModel.MinAllowedPoints.HasValue)
-            {
-                viewModel.MinPointsMessage = $"(Must have at least {viewModel.MinAllowedPoints.Value} points)";
-            }
-
             if (viewModel.EditVendorCode)
             {
                 viewModel.VendorCodeTypeList = new SelectList(
@@ -394,10 +389,6 @@ namespace GRA.Controllers.MissionControl
             {
                 model.MaxPointsMessage = $"(Up to {model.MaxPointLimit.Value} points)";
             }
-            if (model.MinAllowedPoints.HasValue)
-            {
-                model.MinPointsMessage = $"(Must have at least {model.MinAllowedPoints.Value} points)";
-            }
 
             PageTitle = "Create Trigger";
             return View("Detail", model);
@@ -506,10 +497,6 @@ namespace GRA.Controllers.MissionControl
             if (viewModel?.MaxPointLimit != null)
             {
                 viewModel.MaxPointsMessage = $"(Up to {viewModel.MaxPointLimit.Value} points)";
-            }
-            if (viewModel.MinAllowedPoints.HasValue)
-            {
-                viewModel.MinPointsMessage = $"(Must have at least {viewModel.MinAllowedPoints.Value} points)";
             }
             if (trigger.AwardPoints > viewModel.MaxPointLimit)
             {
@@ -906,11 +893,6 @@ namespace GRA.Controllers.MissionControl
                 {
                     model.MaxPointsWarningMessage = $"This Trigger exceeds the maximum of {model.MaxPointLimit.Value} points per required task. Only Administrators can edit the points awarded.";
                 }
-            }
-
-            if (model.MinAllowedPoints.HasValue)
-            {
-                model.MinPointsMessage = $"(Must have at least {model.MinAllowedPoints.Value} points)";
             }
             PageTitle = $"Edit Trigger - {model.Trigger.Name}";
             return View("Detail", model);

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -843,7 +843,7 @@ namespace GRA.Controllers.MissionControl
             int? systemId,
             int? branchId,
             bool? mine,
-            bool? lowPoint,
+            int? lowPoint,
             int? programId,
             int page = 1)
         {
@@ -858,8 +858,9 @@ namespace GRA.Controllers.MissionControl
             {
                 filter.UserIds = new List<int> { GetId(ClaimType.UserId) };
             }
-            else if (lowPoint == true)
+            else if (lowPoint.HasValue)
             {
+                filter.PointsBelowOrEqual = new List<int> { lowPoint.Value };
             }
             else if (branchId.HasValue)
             {
@@ -935,8 +936,11 @@ namespace GRA.Controllers.MissionControl
                         .ThenBy(_ => _.Name);
                 viewModel.ActiveNav = "Mine";
             }
-            else if (lowPoint == true)
+            else if (lowPoint.HasValue)
             {
+                viewModel.BranchList = (await _siteService.GetBranches(lowPoint.Value))
+                   .OrderByDescending(_ => _.Id == GetId(ClaimType.BranchId))
+                   .ThenBy(_ => _.Name);
                 viewModel.ActiveNav = "Low Points";
             }
             else if (branchId.HasValue)

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -123,6 +123,7 @@ namespace GRA.Controllers.MissionControl
             var challengeRequiredList = new List<int>();
 
             model.IgnorePointLimits = UserHasPermission(Permission.IgnorePointLimits);
+            model.LowPointThreshold = await _triggerService.GetLowPointThresholdAsync(GetCurrentSiteId());
             model.MaxPointLimit = await _triggerService
                 .GetMaximumAllowedPointsAsync(GetCurrentSiteId());
             if (!model.IgnorePointLimits
@@ -317,7 +318,13 @@ namespace GRA.Controllers.MissionControl
                         model.Trigger.AwardAttachmentId = attachment.Id;
                     }
                     var trigger = await _triggerService.AddAsync(model.Trigger);
+                    if (model.LowPointThreshold >= trigger.Points)
+                    {
+                        ShowAlertWarning($"Trigger is a low point trigger.");
+                    }
                     ShowAlertSuccess($"Trigger '<strong>{trigger.Name}</strong>' was successfully created");
+
+
                     return RedirectToAction("Index");
                 }
                 catch (GraException gex)
@@ -536,8 +543,8 @@ namespace GRA.Controllers.MissionControl
             var challengeRequiredList = new List<int>();
 
             model.IgnorePointLimits = UserHasPermission(Permission.IgnorePointLimits);
-            model.MaxPointLimit =
-                await _triggerService.GetMaximumAllowedPointsAsync(GetCurrentSiteId());
+            model.MaxPointLimit = await _triggerService.GetMaximumAllowedPointsAsync(GetCurrentSiteId());
+            model.LowPointThreshold = await _triggerService.GetLowPointThresholdAsync(GetCurrentSiteId());
             if (!model.IgnorePointLimits
                 && model.MaxPointLimit.HasValue
                 && model.Trigger.AwardPoints > model.MaxPointLimit)
@@ -770,6 +777,10 @@ namespace GRA.Controllers.MissionControl
                         model.Trigger.AwardAttachmentId = null;
                     }
 
+                    if (model.LowPointThreshold >= model.Trigger.Points)
+                    {
+                        ShowAlertWarning($"Trigger is a low point trigger.");
+                    }
                     ShowAlertSuccess($"Trigger '<strong>{savedtrigger.Name}</strong>' was successfully modified");
                     return RedirectToAction("Index");
                 }

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -843,7 +843,7 @@ namespace GRA.Controllers.MissionControl
             int? systemId,
             int? branchId,
             bool? mine,
-            int? lowPoint,
+            bool? lowPoint,
             int? programId,
             int page = 1)
         {
@@ -858,10 +858,10 @@ namespace GRA.Controllers.MissionControl
             {
                 filter.UserIds = new List<int> { GetId(ClaimType.UserId) };
             }
-            else if (lowPoint.HasValue)
+            else if (lowPoint == true)
             {
-                filter.PointsBelowOrEqual = new List<int> { lowPoint.Value };
-            }
+                filter.PointsBelowOrEqual = await _triggerService.GetLowPointThresholdAsync(GetCurrentSiteId());
+                }
             else if (branchId.HasValue)
             {
                 filter.BranchIds = new List<int> { branchId.Value };
@@ -936,11 +936,11 @@ namespace GRA.Controllers.MissionControl
                         .ThenBy(_ => _.Name);
                 viewModel.ActiveNav = "Mine";
             }
-            else if (lowPoint.HasValue)
+            else if (lowPoint == true)
             {
-                viewModel.BranchList = (await _siteService.GetBranches(lowPoint.Value))
-                   .OrderByDescending(_ => _.Id == GetId(ClaimType.BranchId))
-                   .ThenBy(_ => _.Name);
+                viewModel.BranchList = (await _siteService.GetBranches(GetId(ClaimType.SystemId)))
+                        .OrderByDescending(_ => _.Id == GetId(ClaimType.BranchId))
+                        .ThenBy(_ => _.Name);
                 viewModel.ActiveNav = "Low Points";
             }
             else if (branchId.HasValue)

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -843,7 +843,7 @@ namespace GRA.Controllers.MissionControl
             int? systemId,
             int? branchId,
             bool? mine,
-            bool? lowPoint,
+            bool? lowPoints,
             int? programId,
             int page = 1)
         {
@@ -858,7 +858,7 @@ namespace GRA.Controllers.MissionControl
             {
                 filter.UserIds = new List<int> { GetId(ClaimType.UserId) };
             }
-            else if (lowPoint == true)
+            else if (lowPoints == true)
             {
                 filter.PointsBelowOrEqual = await _triggerService.GetLowPointThresholdAsync(GetCurrentSiteId());
                 }
@@ -925,7 +925,7 @@ namespace GRA.Controllers.MissionControl
                 BranchId = branchId,
                 ProgramId = programId,
                 Mine = mine,
-                LowPoints = lowPoint,
+                LowPoints = lowPoints,
                 SystemList = systemList,
                 ProgramList = await _siteService.GetProgramList()
             };
@@ -936,7 +936,7 @@ namespace GRA.Controllers.MissionControl
                         .ThenBy(_ => _.Name);
                 viewModel.ActiveNav = "Mine";
             }
-            else if (lowPoint == true)
+            else if (lowPoints == true)
             {
                 viewModel.BranchList = (await _siteService.GetBranches(GetId(ClaimType.SystemId)))
                         .OrderByDescending(_ => _.Id == GetId(ClaimType.BranchId))

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -343,7 +343,7 @@ namespace GRA.Controllers.MissionControl
                         model.Trigger.AwardAttachmentId = attachment.Id;
                     }
                     var trigger = await _triggerService.AddAsync(model.Trigger);
-                    if (model.LowPointThreshold != null && model.LowPointThreshold >= trigger.Points)
+                    if (model.LowPointThreshold >= trigger.Points)
                     {
                       ShowAlertWarning("Trigger is a low point trigger.");
                     }
@@ -839,7 +839,7 @@ namespace GRA.Controllers.MissionControl
                         model.Trigger.AwardAttachmentId = null;
                     }
 
-                    if (model.LowPointThreshold != null && model.LowPointThreshold >= model.Trigger.Points)
+                    if (model.LowPointThreshold >= model.Trigger.Points)
                     {
                         ShowAlertWarning("Trigger is a low point trigger.");
                     }

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -87,7 +87,7 @@ namespace GRA.Controllers.MissionControl
                 ProgramList = new SelectList(await _siteService.GetProgramList(), "Id", "Name"),
                 IgnorePointLimits = UserHasPermission(Permission.IgnorePointLimits),
                 MaxPointLimit = await _triggerService.GetMaximumAllowedPointsAsync(site.Id),
-                MinAllowedPoints = await _triggerService.GetMinimumPointsAsync(site.Id)
+                MinAllowedPoints = await _siteService.GetMinimumPointsAsync(site.Id)
             };
 
             if (viewModel.MaxPointLimit.HasValue)
@@ -130,10 +130,9 @@ namespace GRA.Controllers.MissionControl
 
             model.IgnorePointLimits = UserHasPermission(Permission.IgnorePointLimits);
             model.LowPointThreshold = await _siteService.GetLowPointThresholdAsync(GetCurrentSiteId());
-            model.MinAllowedPoints = await _triggerService.GetMinimumPointsAsync(GetCurrentSiteId());
+            model.MinAllowedPoints = await _siteService.GetMinimumPointsAsync(GetCurrentSiteId());
             model.MaxPointLimit = await _triggerService
                 .GetMaximumAllowedPointsAsync(GetCurrentSiteId());
-            model.MinAllowedPoints = await _triggerService.GetMinimumPointsAsync(GetCurrentSiteId());
             if (!model.IgnorePointLimits
                 && model.MaxPointLimit.HasValue
                 && model.Trigger.AwardPoints > model.MaxPointLimit)
@@ -479,7 +478,7 @@ namespace GRA.Controllers.MissionControl
                     await _triggerService.GetMaximumAllowedPointsAsync(site.Id),
                 LowPointThreshold = await _siteService.GetLowPointThresholdAsync(site.Id),
                 BadgeAltText = badge.AltText,
-                MinAllowedPoints = await _triggerService.GetMinimumPointsAsync(site.Id)
+                MinAllowedPoints = await _siteService.GetMinimumPointsAsync(site.Id)
             };
             if (viewModel?.MaxPointLimit != null)
             {
@@ -569,7 +568,7 @@ namespace GRA.Controllers.MissionControl
             model.IgnorePointLimits = UserHasPermission(Permission.IgnorePointLimits);
             model.MaxPointLimit = await _triggerService.GetMaximumAllowedPointsAsync(GetCurrentSiteId());
             model.LowPointThreshold = await _siteService.GetLowPointThresholdAsync(GetCurrentSiteId());
-            model.MinAllowedPoints = await _triggerService.GetMinimumPointsAsync(GetCurrentSiteId());
+            model.MinAllowedPoints = await _siteService.GetMinimumPointsAsync(GetCurrentSiteId());
             if (!model.IgnorePointLimits
                 && model.MaxPointLimit.HasValue
                 && model.Trigger.AwardPoints > model.MaxPointLimit)

--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -85,7 +85,8 @@ namespace GRA.Controllers.MissionControl
                 BranchList = new SelectList(await _siteService.GetAllBranches(), "Id", "Name"),
                 ProgramList = new SelectList(await _siteService.GetProgramList(), "Id", "Name"),
                 IgnorePointLimits = UserHasPermission(Permission.IgnorePointLimits),
-                MaxPointLimit = await _triggerService.GetMaximumAllowedPointsAsync(site.Id)
+                MaxPointLimit = await _triggerService.GetMaximumAllowedPointsAsync(site.Id),
+                LowPointThreshold = await _triggerService.GetLowPointThresholdAsync(site.Id)
             };
 
             if (viewModel.MaxPointLimit.HasValue)
@@ -859,7 +860,6 @@ namespace GRA.Controllers.MissionControl
             }
             else if (lowPoint == true)
             {
-
             }
             else if (branchId.HasValue)
             {
@@ -937,7 +937,7 @@ namespace GRA.Controllers.MissionControl
             }
             else if (lowPoint == true)
             {
-
+                viewModel.ActiveNav = "Low Points";
             }
             else if (branchId.HasValue)
             {

--- a/src/GRA.Controllers/ViewModel/MissionControl/Events/EventsDetailViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Events/EventsDetailViewModel.cs
@@ -1,8 +1,8 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using GRA.Domain.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using GRA.Domain.Model;
 
 namespace GRA.Controllers.ViewModel.MissionControl.Events
 {
@@ -42,7 +42,6 @@ namespace GRA.Controllers.ViewModel.MissionControl.Events
         public GRA.Domain.Model.Location Location { get; set; }
         public SelectList LocationList { get; set; }
         public int? MaxPointLimit { get; set; }
-        public string MaxPointLimitMessage { get; set; }
         public string MaxPointLimitWarningMessage { get; set; }
         public bool NewCommunityExperience { get; set; }
         public SelectList ProgramList { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
@@ -46,9 +46,10 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public bool EditVendorCode { get; set; }
         public bool IgnorePointLimits { get; set; }
         public bool IsSecretCode { get; set; }
-        public int? MaxPointLimit { get; set; }
         public int? LowPointThreshold { get; set; }
+        public int? MaxPointLimit { get; set; }
         public int? MinAllowedPoints { get; set; }
+        public string MinPointsMessage { get; set; }
         public string MaxPointsMessage { get; set; }
         public string MaxPointsWarningMessage { get; set; }
         public SelectList ProgramList { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
@@ -35,6 +35,7 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
 
         [DisplayName("Upload a badge image. Badge images must be square.")]
         public IFormFile BadgeUploadImage { get; set; }
+
         public SelectList BranchList { get; set; }
         public bool CanViewParticipants { get; set; }
         public string ChallengeRequiredList { get; set; }
@@ -45,12 +46,22 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public bool EditMail { get; set; }
         public bool EditVendorCode { get; set; }
         public bool IgnorePointLimits { get; set; }
+
+        public string IsReadOnly
+        {
+            get
+            {
+                return !IgnorePointLimits && !string.IsNullOrEmpty(PointLimitExceededMessage)
+                    ? "readonly"
+                    : null;
+            }
+        }
+
         public bool IsSecretCode { get; set; }
         public int? LowPointThreshold { get; set; }
         public int? MaxPointLimit { get; set; }
         public int? MinAllowedPoints { get; set; }
-        public string MaxPointsMessage { get; set; }
-        public string MaxPointsWarningMessage { get; set; }
+        public string PointLimitExceededMessage { get; set; }
         public SelectList ProgramList { get; set; }
         public ICollection<Event> RelatedEvents { get; set; }
         public bool RemoveAttachment { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
@@ -35,7 +35,6 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
 
         [DisplayName("Upload a badge image. Badge images must be square.")]
         public IFormFile BadgeUploadImage { get; set; }
-
         public SelectList BranchList { get; set; }
         public bool CanViewParticipants { get; set; }
         public string ChallengeRequiredList { get; set; }
@@ -48,6 +47,7 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public bool IgnorePointLimits { get; set; }
         public bool IsSecretCode { get; set; }
         public int? MaxPointLimit { get; set; }
+        public int? LowPointThreshold { get; set; }
         public string MaxPointsMessage { get; set; }
         public string MaxPointsWarningMessage { get; set; }
         public SelectList ProgramList { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
@@ -49,7 +49,6 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public int? LowPointThreshold { get; set; }
         public int? MaxPointLimit { get; set; }
         public int? MinAllowedPoints { get; set; }
-        public string MinPointsMessage { get; set; }
         public string MaxPointsMessage { get; set; }
         public string MaxPointsWarningMessage { get; set; }
         public SelectList ProgramList { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersDetailViewModel.cs
@@ -48,6 +48,7 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public bool IsSecretCode { get; set; }
         public int? MaxPointLimit { get; set; }
         public int? LowPointThreshold { get; set; }
+        public int? MinAllowedPoints { get; set; }
         public string MaxPointsMessage { get; set; }
         public string MaxPointsWarningMessage { get; set; }
         public SelectList ProgramList { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersListViewModel.cs
@@ -12,7 +12,7 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public int? BranchId { get; set; }
         public int? ProgramId { get; set; }
         public bool? Mine { get; set; }
-        public bool? LowPoints { get; set; }
+        public int? LowPoints { get; set; }
         public string ActiveNav { get; set; }
         public string SystemName { get; set; }
         public string BranchName { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersListViewModel.cs
@@ -12,7 +12,7 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public int? BranchId { get; set; }
         public int? ProgramId { get; set; }
         public bool? Mine { get; set; }
-        public int? LowPoints { get; set; }
+        public bool? LowPoints { get; set; }
         public string ActiveNav { get; set; }
         public string SystemName { get; set; }
         public string BranchName { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersListViewModel.cs
@@ -11,6 +11,7 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public int? SystemId { get; set; }
         public int? BranchId { get; set; }
         public int? ProgramId { get; set; }
+        public bool? HideLowPoint { get; set; }
         public bool? Mine { get; set; }
         public bool? LowPoints { get; set; }
         public string ActiveNav { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Triggers/TriggersListViewModel.cs
@@ -12,6 +12,7 @@ namespace GRA.Controllers.ViewModel.MissionControl.Triggers
         public int? BranchId { get; set; }
         public int? ProgramId { get; set; }
         public bool? Mine { get; set; }
+        public bool? LowPoints { get; set; }
         public string ActiveNav { get; set; }
         public string SystemName { get; set; }
         public string BranchName { get; set; }

--- a/src/GRA.Data/Repository/TriggerRepository.cs
+++ b/src/GRA.Data/Repository/TriggerRepository.cs
@@ -124,7 +124,7 @@ namespace GRA.Data.Repository
 
             if (filter.PointsBelowOrEqual.HasValue)
             {
-                triggerList = triggerList.Where(_ => filter.PointsBelowOrEqual >= _.Points);
+                triggerList = triggerList.Where(_ => filter.PointsBelowOrEqual >= _.Points && string.IsNullOrWhiteSpace(_.SecretCode));
             }
 
             if (filter.SecretCodesOnly == true)

--- a/src/GRA.Data/Repository/TriggerRepository.cs
+++ b/src/GRA.Data/Repository/TriggerRepository.cs
@@ -124,7 +124,7 @@ namespace GRA.Data.Repository
 
             if (filter.PointsBelowOrEqual.HasValue)
             {
-                triggerList = triggerList.Where(_ => filter.PointsBelowOrEqual <= _.Points);
+                triggerList = triggerList.Where(_ => filter.PointsBelowOrEqual >= _.Points);
             }
 
             if (filter.SecretCodesOnly == true)

--- a/src/GRA.Data/Repository/TriggerRepository.cs
+++ b/src/GRA.Data/Repository/TriggerRepository.cs
@@ -122,9 +122,9 @@ namespace GRA.Data.Repository
                                                 || _.SecretCode.Contains(filter.Search));
             }
 
-            if (filter.PointsBelowOrEqual?.Any() == true)
+            if (filter.PointsBelowOrEqual.HasValue)
             {
-                triggerList = triggerList.Where(_ => filter.PointsBelowOrEqual.Any(val => val <= _.Points));
+                triggerList = triggerList.Where(_ => filter.PointsBelowOrEqual <= _.Points);
             }
 
             if (filter.SecretCodesOnly == true)

--- a/src/GRA.Data/Repository/TriggerRepository.cs
+++ b/src/GRA.Data/Repository/TriggerRepository.cs
@@ -122,6 +122,11 @@ namespace GRA.Data.Repository
                                                 || _.SecretCode.Contains(filter.Search));
             }
 
+            if(filter.LowPointActivated == true)
+            {
+                triggerList = triggerList.Where(_ => filter.LowPointActivated == true);
+            }
+
             if (filter.SecretCodesOnly == true)
             {
                 triggerList = triggerList.Where(_ => !string.IsNullOrWhiteSpace(_.SecretCode));

--- a/src/GRA.Data/Repository/TriggerRepository.cs
+++ b/src/GRA.Data/Repository/TriggerRepository.cs
@@ -122,9 +122,9 @@ namespace GRA.Data.Repository
                                                 || _.SecretCode.Contains(filter.Search));
             }
 
-            if(filter.LowPointActivated == true)
+            if (filter.PointsBelowOrEqual?.Any() == true)
             {
-                triggerList = triggerList.Where(_ => filter.LowPointActivated == true);
+                triggerList = triggerList.Where(_ => filter.PointsBelowOrEqual.Any(val => val <= _.Points));
             }
 
             if (filter.SecretCodesOnly == true)

--- a/src/GRA.Domain.Model/Filters/TriggerFilter.cs
+++ b/src/GRA.Domain.Model/Filters/TriggerFilter.cs
@@ -6,7 +6,7 @@ namespace GRA.Domain.Model.Filters
     public class TriggerFilter : BaseFilter
     {
         public bool? SecretCodesOnly { get; set; }
-        public ICollection<int> PointsBelowOrEqual { get; set; }
+        public int? PointsBelowOrEqual { get; set; }
         public TriggerFilter(int? page = null) : base(page) { }
     }
 }

--- a/src/GRA.Domain.Model/Filters/TriggerFilter.cs
+++ b/src/GRA.Domain.Model/Filters/TriggerFilter.cs
@@ -1,12 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 
 namespace GRA.Domain.Model.Filters
 {
     public class TriggerFilter : BaseFilter
     {
         public bool? SecretCodesOnly { get; set; }
-        public bool? LowPointActivated { get; set; }
-        public ICollection<int> LowPointsIds { get; set; }
+        public ICollection<int> PointsBelowOrEqual { get; set; }
         public TriggerFilter(int? page = null) : base(page) { }
     }
 }

--- a/src/GRA.Domain.Model/Filters/TriggerFilter.cs
+++ b/src/GRA.Domain.Model/Filters/TriggerFilter.cs
@@ -1,11 +1,12 @@
-﻿namespace GRA.Domain.Model.Filters
+﻿using System.Collections.Generic;
+
+namespace GRA.Domain.Model.Filters
 {
     public class TriggerFilter : BaseFilter
     {
         public bool? SecretCodesOnly { get; set; }
-
         public bool? LowPointActivated { get; set; }
-
+        public ICollection<int> LowPointsIds { get; set; }
         public TriggerFilter(int? page = null) : base(page) { }
     }
 }

--- a/src/GRA.Domain.Model/Filters/TriggerFilter.cs
+++ b/src/GRA.Domain.Model/Filters/TriggerFilter.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-
-namespace GRA.Domain.Model.Filters
+﻿namespace GRA.Domain.Model.Filters
 {
     public class TriggerFilter : BaseFilter
     {

--- a/src/GRA.Domain.Model/Filters/TriggerFilter.cs
+++ b/src/GRA.Domain.Model/Filters/TriggerFilter.cs
@@ -4,6 +4,8 @@
     {
         public bool? SecretCodesOnly { get; set; }
 
+        public bool? LowPointActivated { get; set; }
+
         public TriggerFilter(int? page = null) : base(page) { }
     }
 }

--- a/src/GRA.Domain.Service/SiteService.cs
+++ b/src/GRA.Domain.Service/SiteService.cs
@@ -204,6 +204,14 @@ namespace GRA.Domain.Service
             return IsSet ? SetValue : (int?)null;
         }
 
+        public async Task<int?> GetMinimumPointsAsync(int siteId)
+        {
+            var (IsSet, SetValue) = await _siteLookupService.GetSiteSettingIntAsync(siteId,
+                SiteSettingKey.Triggers.DisallowTriggersBelowPoints);
+
+            return IsSet ? SetValue : (int?)null;
+        }
+
         public async Task<DataWithCount<IEnumerable<Site>>> GetPaginatedListAsync(BaseFilter filter)
         {
             VerifyManagementPermission();

--- a/src/GRA.Domain.Service/SiteService.cs
+++ b/src/GRA.Domain.Service/SiteService.cs
@@ -196,21 +196,6 @@ namespace GRA.Domain.Service
                 Count = await _branchRepository.CountAsync(filter)
             };
         }
-        public async Task<int?> GetLowPointThresholdAsync(int siteId)
-        {
-            var (IsSet, SetValue) = await _siteLookupService.GetSiteSettingIntAsync(siteId,
-                SiteSettingKey.Triggers.LowPointThreshold);
-
-            return IsSet ? SetValue : (int?)null;
-        }
-
-        public async Task<int?> GetMinimumPointsAsync(int siteId)
-        {
-            var (IsSet, SetValue) = await _siteLookupService.GetSiteSettingIntAsync(siteId,
-                SiteSettingKey.Triggers.DisallowTriggersBelowPoints);
-
-            return IsSet ? SetValue : (int?)null;
-        }
 
         public async Task<DataWithCount<IEnumerable<Site>>> GetPaginatedListAsync(BaseFilter filter)
         {

--- a/src/GRA.Domain.Service/SiteService.cs
+++ b/src/GRA.Domain.Service/SiteService.cs
@@ -196,6 +196,13 @@ namespace GRA.Domain.Service
                 Count = await _branchRepository.CountAsync(filter)
             };
         }
+        public async Task<int?> GetLowPointThresholdAsync(int siteId)
+        {
+            var (IsSet, SetValue) = await _siteLookupService.GetSiteSettingIntAsync(siteId,
+                SiteSettingKey.Triggers.LowPointThreshold);
+
+            return IsSet ? SetValue : (int?)null;
+        }
 
         public async Task<DataWithCount<IEnumerable<Site>>> GetPaginatedListAsync(BaseFilter filter)
         {

--- a/src/GRA.Domain.Service/TriggerService.cs
+++ b/src/GRA.Domain.Service/TriggerService.cs
@@ -107,14 +107,6 @@ namespace GRA.Domain.Service
             return IsSet ? SetValue : (int?)null;
         }
 
-        public async Task<int?> GetMinimumPointsAsync(int siteId)
-        {
-            var (IsSet, SetValue) = await _siteLookupService.GetSiteSettingIntAsync(siteId,
-                SiteSettingKey.Triggers.DisallowTriggersBelowPoints);
-
-            return IsSet ? SetValue : (int?)null;
-        }
-
         public async Task<DataWithCount<ICollection<Trigger>>> GetPaginatedListAsync(TriggerFilter filter)
         {
             VerifyManagementPermission();

--- a/src/GRA.Domain.Service/TriggerService.cs
+++ b/src/GRA.Domain.Service/TriggerService.cs
@@ -115,6 +115,14 @@ namespace GRA.Domain.Service
             return IsSet ? SetValue : (int?)null;
         }
 
+        public async Task<int?> GetMinimumPointsAsync(int siteId)
+        {
+            var (IsSet, SetValue) = await _siteLookupService.GetSiteSettingIntAsync(siteId,
+                SiteSettingKey.Triggers.DisallowTriggersBelowPoints);
+
+            return IsSet ? SetValue : (int?)null;
+        }
+
         public async Task<DataWithCount<ICollection<Trigger>>> GetPaginatedListAsync(TriggerFilter filter)
         {
             VerifyManagementPermission();

--- a/src/GRA.Domain.Service/TriggerService.cs
+++ b/src/GRA.Domain.Service/TriggerService.cs
@@ -107,14 +107,6 @@ namespace GRA.Domain.Service
             return IsSet ? SetValue : (int?)null;
         }
 
-        public async Task<int?> GetLowPointThresholdAsync(int siteId)
-        {
-            var (IsSet, SetValue) = await _siteLookupService.GetSiteSettingIntAsync(siteId,
-                SiteSettingKey.Triggers.LowPointThreshold);
-
-            return IsSet ? SetValue : (int?)null;
-        }
-
         public async Task<int?> GetMinimumPointsAsync(int siteId)
         {
             var (IsSet, SetValue) = await _siteLookupService.GetSiteSettingIntAsync(siteId,

--- a/src/GRA.Domain.Service/TriggerService.cs
+++ b/src/GRA.Domain.Service/TriggerService.cs
@@ -107,6 +107,14 @@ namespace GRA.Domain.Service
             return IsSet ? SetValue : (int?)null;
         }
 
+        public async Task<int?> GetLowPointThresholdAsync(int siteId)
+        {
+            var (IsSet, SetValue) = await _siteLookupService.GetSiteSettingIntAsync(siteId,
+                SiteSettingKey.Triggers.LowPointThreshold);
+
+            return IsSet ? SetValue : (int?)null;
+        }
+
         public async Task<DataWithCount<ICollection<Trigger>>> GetPaginatedListAsync(TriggerFilter filter)
         {
             VerifyManagementPermission();

--- a/src/GRA.Web/Areas/MissionControl/Views/Events/AddEditStreaming.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Events/AddEditStreaming.cshtml
@@ -386,7 +386,10 @@
                         <div class="row my-2">
                             <div class="col-12">
                                 <label asp-for="AwardPoints" class="col-form-label"></label>
-                                <small>@Model.MaxPointLimitMessage</small>
+                                @if (Model.MaxPointLimit.HasValue)
+                                {
+                                    <small>(Up to @Model.MaxPointLimit points)</small>
+                                }
                                 <input asp-for="AwardPoints"
                                        min="0"
                                        class="form-control secretCodeField @(Model.IncludeSecretCode ? "" : "ignore")" />

--- a/src/GRA.Web/Areas/MissionControl/Views/Events/Create.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Events/Create.cshtml
@@ -263,7 +263,10 @@
                         <div class="row my-2">
                             <div class="col-12">
                                 <label asp-for="AwardPoints" class="col-form-label"></label>
-                                <small>@Model.MaxPointLimitMessage</small>
+                                @if (Model.MaxPointLimit.HasValue)
+                                {
+                                    <small>(Up to @Model.MaxPointLimit points)</small>
+                                }
                                 <input asp-for="AwardPoints"
                                        min="0"
                                        class="form-control secretCodeField @(Model.IncludeSecretCode ? "" : "ignore")" />

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
@@ -137,13 +137,12 @@
             on @Model.Trigger.CreatedAt
         </div>
 
-        @if (!string.IsNullOrEmpty(Model.MaxPointsWarningMessage))
+        @if (!string.IsNullOrEmpty(Model.PointLimitExceededMessage))
         {
             <div class="col-12 col-sm-6 offset-sm-3 mb-3">
                 <div class="alert alert-warning d-flex align-items-stretch">
-                    <span class="fas fa-exclamation-circle fa-2x pt-2 me-3"
-                          aria-hidden="true"></span>
-                    <span>@Model.MaxPointsWarningMessage</span>
+                    <span class="fas fa-exclamation-circle fa-lg text-warning pt-2 me-3" aria-hidden="true"></span>
+                    <span>@Html.Raw(Model.PointLimitExceededMessage)</span>
                 </div>
             </div>
         }
@@ -153,7 +152,7 @@
         <label asp-for="Trigger.Name" class="col-form-label"></label>
         <input asp-for="Trigger.Name"
                class="form-control trigger-name-field"
-               readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)" />
+               readonly="@Model.IsReadOnly" />
         <span asp-validation-for="Trigger.Name" class="text-danger"></span>
     </div>
 
@@ -198,7 +197,7 @@
                 <div>
                     <input asp-for="Trigger.SecretCode"
                            class="form-control"
-                           readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)" />
+                           readonly="@Model.IsReadOnly" />
                     <span id="SecretCode-Validation"
                           asp-validation-for="Trigger.SecretCode"
                           class="text-success"></span>
@@ -225,10 +224,19 @@
 
             <div class="col-12 mb-3">
                 <label asp-for="Trigger.Points" class="col-form-label"></label>
-                <div class="col-12"><small><em>Must have at least @Model.MinAllowedPoints points</em></small></div>
+                @if (Model.MinAllowedPoints > 0)
+                {
+                    <div class="col-12">
+                        <small>
+                            <em>
+                                Must have at least @Model.MinAllowedPoints points
+                            </em>
+                        </small>
+                    </div>
+                }
                 <input asp-for="Trigger.Points"
                        class="form-control"
-                       readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)" />
+                       readonly="@Model.IsReadOnly" />
                 <span asp-validation-for="Trigger.Points" class="text-danger"></span>
             </div>
 
@@ -244,7 +252,7 @@
                             <input asp-for="Trigger.ItemsRequired"
                                    class="form-control"
                                    min="0"
-                                   readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)" />
+                                   readonly="@Model.IsReadOnly" />
                             <p class="form-control-plaintext"><strong>of the following:</strong></p>
                             <span asp-validation-for="Trigger.ItemsRequired" class="text-danger" />
                         </div>
@@ -314,7 +322,7 @@
                         <button type="button"
                                 id="addButton"
                                 class="btn btn-outline-warning"
-                                disabled="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "disabled" : null)">
+                                disabled="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.PointLimitExceededMessage) ? "disabled" : null)">
                             Add Challenges or Triggers
                         </button>
                     </div>
@@ -326,7 +334,7 @@
                 <select asp-for="Trigger.LimitToSystemId"
                         asp-items="Model.SystemList"
                         class="form-select"
-                        disabled="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "disabled" : null)">
+                        disabled="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.PointLimitExceededMessage) ? "disabled" : null)">
                     <option value="">No</option>
                 </select>
                 <span asp-validation-for="Trigger.LimitToSystemId" class="text-danger"></span>
@@ -337,7 +345,7 @@
                 <select asp-for="Trigger.LimitToBranchId"
                         asp-items="Model.BranchList"
                         class="form-select"
-                        disabled="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "disabled" : null)">
+                        disabled="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.PointLimitExceededMessage) ? "disabled" : null)">
                     <option value="">No</option>
                 </select>
                 <span asp-validation-for="Trigger.LimitToBranchId" class="text-danger"></span>
@@ -348,7 +356,7 @@
                 <select asp-for="Trigger.LimitToProgramId"
                         asp-items="Model.ProgramList"
                         class="form-select"
-                        disabled="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "disabled" : null)">
+                        disabled="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.PointLimitExceededMessage) ? "disabled" : null)">
                     <option value="">No</option>
                 </select>
                 <span asp-validation-for="Trigger.LimitToProgramId" class="text-danger"></span>
@@ -363,7 +371,7 @@
                 <input asp-for="Trigger.ActivationDate"
                        type="form"
                        class="form-control"
-                       readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)" />
+                       readonly="@Model.IsReadOnly" />
             </div>
             <span asp-validation-for="Trigger.ActivationDate" class="text-danger"></span>
         </div>
@@ -378,19 +386,28 @@
                 <label asp-for="Trigger.AwardMessage"></label>
                 <textarea asp-for="Trigger.AwardMessage"
                           class="form-control"
-                          readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)"></textarea>
+                          readonly="@Model.IsReadOnly"></textarea>
                 <span asp-validation-for="Trigger.AwardMessage" class="text-danger"></span>
             </div>
             <div class="col-12">
                 <label asp-for="Trigger.AwardPoints"></label>
             </div>
-            <div class="col-12 mb-3"><small><em>@Model.MaxPointsMessage</em></small></div>
+            @if (Model.MaxPointLimit.HasValue)
+            {
+                <div class="col-12">
+                    <small>
+                        <em>
+                            (Up to @Model.MaxPointLimit points)
+                        </em>
+                    </small>
+                </div>
+            }
             <div class="col-12 mb-3">
                 <input asp-for="Trigger.AwardPoints"
                        value="@(Model.Trigger?.AwardPoints ?? 0)"
                        min="0"
                        class="form-control"
-                       readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)" />
+                       readonly="@Model.IsReadOnly" />
                 <span asp-validation-for="Trigger.AwardPoints" class="text-danger"></span>
             </div>
             <div class="row mb-3">
@@ -532,7 +549,7 @@
                             <description gra-description-for="Trigger.AwardPrizeName"></description>
                             <input asp-for="Trigger.AwardPrizeName"
                                    class="form-control"
-                                   readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)" />
+                                   readonly="@Model.IsReadOnly" />
                             <span asp-validation-for="Trigger.AwardPrizeName"
                                   class="text-danger"></span>
                         </div>
@@ -543,7 +560,7 @@
                                    class="col-form-label"></label>
                             <textarea asp-for="Trigger.AwardPrizeRedemptionInstructions"
                                       class="form-control"
-                                      readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)"></textarea>
+                                      readonly="@Model.IsReadOnly"></textarea>
                             <span asp-validation-for="Trigger.AwardPrizeRedemptionInstructions"
                                   class="text-danger"></span>
                         </div>
@@ -591,7 +608,7 @@
                                        class="col-form-label"></label>
                                 <input asp-for="Trigger.AwardMailSubject"
                                        class="form-control"
-                                       readonly="@(!Model.EditMail || (!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage)) ? "readonly" : null)" />
+                                       readonly="@(!Model.EditMail || (!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.PointLimitExceededMessage)) ? "readonly" : null)" />
                                 <span asp-validation-for="Trigger.AwardMailSubject"
                                       class="text-danger"></span>
                             </div>
@@ -601,7 +618,7 @@
                                 <label asp-for="Trigger.AwardMail" class="col-form-label"></label>
                                 <textarea asp-for="Trigger.AwardMail"
                                           class="form-control"
-                                          readonly="@(!Model.EditMail || (!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage)) ? "readonly" : null)"></textarea>
+                                          readonly="@(!Model.EditMail || (!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.PointLimitExceededMessage)) ? "readonly" : null)"></textarea>
                                 <span asp-validation-for="Trigger.AwardMail"
                                       class="text-danger"></span>
                             </div>
@@ -716,7 +733,7 @@
     <div class="mb-3 d-flex justify-content-end my-4">
         <a asp-action="Index"
            class="btn btn-outline-secondary mx-2">Return to List</a>
-        @if (Model.IgnorePointLimits || string.IsNullOrEmpty(Model.MaxPointsWarningMessage))
+        @if (Model.IgnorePointLimits || string.IsNullOrEmpty(Model.PointLimitExceededMessage))
         {
             <button type="submit"
                     id="saveButton"
@@ -730,9 +747,8 @@
     </div>
 </form>
 
-@if (Model.IgnorePointLimits && Model.MaxPointLimit != null)
+@if (Model.IgnorePointLimits && (Model.MaxPointLimit.HasValue || Model.MinAllowedPoints.HasValue))
 {
-
     <div class="modal fade"
          id="warningModal"
          tabindex="-1"
@@ -742,20 +758,19 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h1 class="modal-title h4" id="deleteModalLabel">
-                        <button type="button"
-                                class="btn-close"
-                                data-bs-dismiss="modal"
-                                aria-label="Close">
-                        </button>
-                        Warning: Award points exceed maximum
+                        Warning: Point limits exceeded
                     </h1>
+                    <button type="button"
+                            class="btn-close"
+                            data-bs-dismiss="modal"
+                            aria-label="Close">
+                    </button>
                 </div>
-                <div class="modal-body">
-                    <span class="fas fa-exclamation-triangle fa-lg text-danger pt-2 me-3" aria-hidden="true"></span>
-                    <span id="modal-text">
-                        The awarded points for this trigger exceed the maximum of
-                        <strong>@Model.MaxPointLimit points</strong>. Do you wish to continue?
-                    </span>
+                <div class="modal-body p-0">
+                    <div class="modal-body d-flex align-items-stretch">
+                        <span class="fas fa-exclamation-triangle fa-lg text-danger pt-2 me-3" aria-hidden="true"></span>
+                        <span id="modal-text"></span>
+                    </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button"
@@ -773,80 +788,77 @@
             </div>
         </div>
     </div>
-
 }
 
-<div class="row">
-    <div class="modal fade"
-         id="listModal"
-         tabindex="-1"
-         role="dialog"
-         data-bs-backdrop="static"
-         data-bs-keyboard="false"
-         aria-labelledby="listModalLabel">
-        <div class="modal-dialog modal-xl" role="document">
-            <div class="modal-content">
-                <div class="card">
-                    <div class="card-header">
-                        <h1 class="h4 modal-title lead">Add requirement</h1>
+<div class="modal fade"
+     id="listModal"
+     tabindex="-1"
+     role="dialog"
+     data-bs-backdrop="static"
+     data-bs-keyboard="false"
+     aria-labelledby="listModalLabel">
+    <div class="modal-dialog modal-xl" role="document">
+        <div class="modal-content">
+            <div class="card">
+                <div class="card-header">
+                    <h1 class="h4 modal-title lead">Add requirement</h1>
+                </div>
+                <div class="card-body pt-2">
+                    <div class="row">
+                        <div class="col-12 mb-2">
+                            <ul class="nav nav-pills">
+                                <li id="All" class="nav-item requirementScope">
+                                    <a class="nav-link active">All</a>
+                                </li>
+                                <li id="System" class="nav-item requirementScope">
+                                    <a class="nav-link">My System</a>
+                                </li>
+                                <li id="Branch" class="nav-item requirementScope">
+                                    <a class="nav-link">My Branch</a>
+                                </li>
+                                <li id="Mine" class="nav-item requirementScope">
+                                    <a class="nav-link">Mine</a>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
-                    <div class="card-body pt-2">
-                        <div class="row">
-                            <div class="col-12 mb-2">
-                                <ul class="nav nav-pills">
-                                    <li id="All" class="nav-item requirementScope">
-                                        <a class="nav-link active">All</a>
-                                    </li>
-                                    <li id="System" class="nav-item requirementScope">
-                                        <a class="nav-link">My System</a>
-                                    </li>
-                                    <li id="Branch" class="nav-item requirementScope">
-                                        <a class="nav-link">My Branch</a>
-                                    </li>
-                                    <li id="Mine" class="nav-item requirementScope">
-                                        <a class="nav-link">Mine</a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                        <div class="row mb-2">
-                            <div class="col-12">
-                                <div class="input-group">
-                                    <input id="searchText"
-                                           class="form-control"
-                                           placeholder="Enter text to search for a challenge here" />
-                                    <button type="button"
-                                            id="clearButton"
-                                            class="btn btn-outline-secondary">
-                                        Clear
-                                    </button>
-                                    <button type="button"
-                                            id="searchButton"
-                                            class="btn btn-outline-primary">
-                                        Search
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-                        <div id="searchMessage" class="row d-none">
-                            <div class="col-12">
-                                <p class="alert-sm alert-info">
-                                    Searching for '<strong id="searchTerm"></strong>'
-                                </p>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div id="modalRequirementList" class="col-12">
+                    <div class="row mb-2">
+                        <div class="col-12">
+                            <div class="input-group">
+                                <input id="searchText"
+                                       class="form-control"
+                                       placeholder="Enter text to search for a challenge here" />
+                                <button type="button"
+                                        id="clearButton"
+                                        class="btn btn-outline-secondary">
+                                    Clear
+                                </button>
+                                <button type="button"
+                                        id="searchButton"
+                                        class="btn btn-outline-primary">
+                                    Search
+                                </button>
                             </div>
                         </div>
                     </div>
-                    <div class="modal-footer">
-                        <button type="button"
-                                class="btn btn-outline-secondary"
-                                data-bs-dismiss="modal">
-                            Close
-                        </button>
+                    <div id="searchMessage" class="row d-none">
+                        <div class="col-12">
+                            <p class="alert-sm alert-info">
+                                Searching for '<strong id="searchTerm"></strong>'
+                            </p>
+                        </div>
                     </div>
+                    <div class="row">
+                        <div id="modalRequirementList" class="col-12">
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button"
+                            class="btn btn-outline-secondary"
+                            data-bs-dismiss="modal">
+                        Close
+                    </button>
                 </div>
             </div>
         </div>
@@ -885,8 +897,8 @@
 
         $(document).on("click", ".addRequirementButton", function () {
             if (!$(this).hasClass("disabled")) {
-                var badgeId = $(this).data("badgeid");
-                var challengeId = $(this).data("challengeid");
+                let badgeId = $(this).data("badgeid");
+                let challengeId = $(this).data("challengeid");
 
                 if (challengeId != "") {
                     challengeIds.push(challengeId);
@@ -898,8 +910,8 @@
                 }
                 $("#noRequirements").addClass("d-none");
 
-                var row = $(this).parent().parent().clone();
-                var addedItem = row.find(".addRequirementButton");
+                let row = $(this).parent().parent().clone();
+                let addedItem = row.find(".addRequirementButton");
                 addedItem.removeClass("addRequirementButton")
                 addedItem.children().removeClass("fa-plus");
                 addedItem.children().addClass("fa-times");
@@ -916,8 +928,8 @@
         });
 
         $(document).on("click", "#removeRequirementButton", function () {
-            var badgeId = $(this).data("badgeid");
-            var challengeId = $(this).data("challengeid");
+            let badgeId = $(this).data("badgeid");
+            let challengeId = $(this).data("challengeid");
 
             if (challengeId != "") {
                 challengeIds.splice(challengeIds.indexOf(challengeId), 1);
@@ -978,10 +990,10 @@
         });
 
         $("#Trigger_LimitToSystemId").on("change", function () {
-            var systemId = $(this).val();
-            var branchList = $("#Trigger_LimitToBranchId");
-            var branchId = branchList.val();
-            var url = "@Url.Action("GetBranches", "Lookup", new { Area = string.Empty })";
+            let systemId = $(this).val();
+            let branchList = $("#Trigger_LimitToBranchId");
+            let branchId = branchList.val();
+            let url = "@Url.Action("GetBranches", "Lookup", new { Area = string.Empty })";
 
             $.getJSON(url, { systemId: systemId, branchId: branchId, listAll: "true", prioritize: "true" }, function (response) {
                 branchList.empty();
@@ -1001,7 +1013,7 @@
         });
 
         $('#AttachmentUploadFile:file').on('fileselect', function (event, numFiles, label) {
-            var input = $(this).parents('.input-group').find(':text'),
+            let input = $(this).parents('.input-group').find(':text'),
                 log = numFiles > 1 ? numFiles = ' files selected' : label;
 
             if (input.length) {
@@ -1067,11 +1079,11 @@
 
         $("#Trigger_SecretCode").on("blur", function () {
             if ($(this).val() != "" && !$(this).hasClass("input-validation-error")) {
-                var secretCode = $(this).val();
+                let secretCode = $(this).val();
                 if (secretCode != "") {
                     if (secretCode != "@Model.Trigger?.SecretCode") {
-                        var codeCheckUrl = "@Url.Action("SecretCodeInUse", "Lookup")";
-                        var icon = $("#SecretCode-Icon");
+                        let codeCheckUrl = "@Url.Action("SecretCodeInUse", "Lookup")";
+                        let icon = $("#SecretCode-Icon");
                         icon.removeClass("d-none fa-times fa-check");
                         icon.addClass("fa-spinner fa-spin");
                         $.post(codeCheckUrl, { secretCode: secretCode }, function (response) {
@@ -1117,28 +1129,34 @@
         });
     </script>
 
-    @if (Model.IgnorePointLimits && Model.MaxPointLimit != null)
+    @if (Model.IgnorePointLimits && (Model.MaxPointLimit.HasValue || Model.MinAllowedPoints.HasValue))
     {
         <script>
             $("#saveButton").on("click", function (e) {
                 e.preventDefault();
+                let messages = [];
+
                 if ($("#Trigger_AwardPoints").val() > @Model.MaxPointLimit) {
-            @if (Model.Trigger != null)
-            {
-                <text>
-                                if ($("#Trigger_AwardPoints").val() != @Model.Trigger.AwardPoints) {
-                                    $('#warningModal').modal("show");
-                                                                                                            }
-                                else {
-                                    $("#triggerForm").submit();
-                                                                                                            }
-                </text>
-            }
-            else
-            {
-                @:$('#warningModal').modal("show");
-            }
-                                                                            } else {
+                    messages.push("The awarded points for this trigger exceed the configured maximum of <strong>"
+                        + @Model.MaxPointLimit
+                        + "</strong>. Override the restriction?");
+                }
+
+                if ($("#Trigger_Points").val() < @Model.MinAllowedPoints) {
+                    messages.push("The activation points for this trigger are below the configured minimum of <strong>"
+                        + @Model.MinAllowedPoints
+                        + "</strong>. Override the restriction?");
+                }
+
+                if(messages.length > 0) {
+                    $("#modal-text").html("");
+                    messages.forEach(function(item, _) {
+                        $("#modal-text").html($("#modal-text").html() + "<p>" + item + "</p>");
+                    });
+                    $("#warningModal").modal("show");
+                }
+                else
+                {
                     $("#triggerForm").submit();
                 }
             });
@@ -1148,6 +1166,7 @@
             });
 
             $("#warningModal").on("hide.bs.modal", function () {
+                ResetSpinners();
                 $("#saveButton").removeClass("disabled");
                 $("#saveButton").find(".fa-spinner").addClass("hidden");
             });

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
@@ -225,7 +225,7 @@
 
             <div class="col-12 mb-3">
                 <label asp-for="Trigger.Points" class="col-form-label"></label>
-                <div class="col-12 mb-3"><small><em>@Model.MinPointsMessage</em></small></div>
+                <div class="col-12"><small><em>@Model.MinPointsMessage</em></small></div>
                 <input asp-for="Trigger.Points"
                        class="form-control"
                        readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)" />

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
@@ -225,7 +225,7 @@
 
             <div class="col-12 mb-3">
                 <label asp-for="Trigger.Points" class="col-form-label"></label>
-                <div class="col-12"><small><em>@Model.MinPointsMessage</em></small></div>
+                <div class="col-12"><small><em>Must have at least @Model.MinAllowedPoints points</em></small></div>
                 <input asp-for="Trigger.Points"
                        class="form-control"
                        readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)" />

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Detail.cshtml
@@ -225,6 +225,7 @@
 
             <div class="col-12 mb-3">
                 <label asp-for="Trigger.Points" class="col-form-label"></label>
+                <div class="col-12 mb-3"><small><em>@Model.MinPointsMessage</em></small></div>
                 <input asp-for="Trigger.Points"
                        class="form-control"
                        readonly="@(!Model.IgnorePointLimits && !string.IsNullOrEmpty(Model.MaxPointsWarningMessage) ? "readonly" : null)" />

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Index.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Index.cshtml
@@ -55,6 +55,12 @@
                    asp-route-ProgramId="@Model.ProgramId"
                    asp-route-Mine="True">Mine</a>
             </li>
+            <li class="nav-item">
+                <a class="nav-link @(Model.ActiveNav == "Low Points" ? "active" : "")"
+                   asp-route-Search="@Model.Search"
+                   asp-route-ProgramId="@Model.ProgramId"
+                   asp-route-LowPoints="True">Low Points</a>
+            </li>
             <li class="nav-item d-none d-sm-block"><a class="nav-link disabled">|</a></li>
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle"
@@ -110,6 +116,10 @@
     @if (Model.Mine == true)
     {
         <input asp-for="Mine" type="hidden" />
+    }
+    @if (Model.LowPoints == true)
+    {
+        <input asp-for="LowPoints" type="hidden" />
     }
     @if (Model.ProgramId.HasValue)
     {

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Index.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Index.cshtml
@@ -55,12 +55,15 @@
                    asp-route-ProgramId="@Model.ProgramId"
                    asp-route-Mine="True">Mine</a>
             </li>
-            <li class="nav-item">
-                <a class="nav-link @(Model.ActiveNav == "Low Points" ? "active" : "")"
+            @if (Model.HideLowPoint == false)
+            {
+                <li class="nav-item">
+                    <a class="nav-link @(Model.ActiveNav == "Low Points" ? "active" : "")"
                    asp-route-Search="@Model.Search"
                    asp-route-ProgramId="@Model.ProgramId"
                    asp-route-LowPoints="True">Low Points</a>
             </li>
+            }
             <li class="nav-item d-none d-sm-block"><a class="nav-link disabled">|</a></li>
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle"

--- a/src/GRA.Web/Areas/MissionControl/Views/Triggers/Index.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Triggers/Index.cshtml
@@ -117,7 +117,7 @@
     {
         <input asp-for="Mine" type="hidden" />
     }
-    @if (Model.LowPoints == true)
+    @if (Model.LowPoints.HasValue)
     {
         <input asp-for="LowPoints" type="hidden" />
     }

--- a/src/GRA/SiteSettingDefinitions.cs
+++ b/src/GRA/SiteSettingDefinitions.cs
@@ -130,7 +130,14 @@ namespace GRA
                 [SiteSettingKey.Triggers.LowPointThreshold] = new SiteSettingDefinition
                 {
                     Name = "Low point threshold for triggers",
-                    Info = "Triggers activated with this many points or fewer are considered to be low point activated",
+                    Info = "Triggers activated with this many points or fewer are considered to be low point activated.",
+                    Category = typeof(SiteSettingKey.Triggers).Name,
+                    Format = SiteSettingFormat.Integer
+                },
+                [SiteSettingKey.Triggers.DisallowTriggersBelowPoints] = new SiteSettingDefinition
+                {
+                    Name = "Disallow triggers below these points",
+                    Info = "Triggers cannot be created below this amount of points.",
                     Category = typeof(SiteSettingKey.Triggers).Name,
                     Format = SiteSettingFormat.Integer
                 },

--- a/src/GRA/SiteSettingDefinitions.cs
+++ b/src/GRA/SiteSettingDefinitions.cs
@@ -127,6 +127,13 @@ namespace GRA
                     Category = typeof(SiteSettingKey.Triggers).Name,
                     Format = SiteSettingFormat.Integer
                 },
+                [SiteSettingKey.Triggers.LowPointThreshold] = new SiteSettingDefinition
+                {
+                    Name = "Low point threshold for triggers",
+                    Info = "Triggers activated with this many points or fewer are considered to be low point activated",
+                    Category = typeof(SiteSettingKey.Triggers).Name,
+                    Format = SiteSettingFormat.Integer
+                },
                 [SiteSettingKey.Users.MaximumHouseholdSizeBeforeGroup] = new SiteSettingDefinition
                 {
                     Name = "Maximum household size before group",

--- a/src/GRA/SiteSettingDefinitions.cs
+++ b/src/GRA/SiteSettingDefinitions.cs
@@ -122,7 +122,7 @@ namespace GRA
                 },
                 [SiteSettingKey.Triggers.DisallowTriggersBelowPoints] = new SiteSettingDefinition
                 {
-                    Name = "Disallow triggers below these points",
+                    Name = "Disallow triggers which activate at point values below the specified number of points",
                     Info = "Triggers cannot be created below this amount of points.",
                     Category = typeof(SiteSettingKey.Triggers).Name,
                     Format = SiteSettingFormat.Integer

--- a/src/GRA/SiteSettingDefinitions.cs
+++ b/src/GRA/SiteSettingDefinitions.cs
@@ -120,6 +120,13 @@ namespace GRA
                     Category = typeof(SiteSettingKey.Users).Name,
                     Format = SiteSettingFormat.Boolean,
                 },
+                [SiteSettingKey.Triggers.DisallowTriggersBelowPoints] = new SiteSettingDefinition
+                {
+                    Name = "Disallow triggers below these points",
+                    Info = "Triggers cannot be created below this amount of points.",
+                    Category = typeof(SiteSettingKey.Triggers).Name,
+                    Format = SiteSettingFormat.Integer
+                },
                 [SiteSettingKey.Triggers.MaxPointsPerTrigger] = new SiteSettingDefinition
                 {
                     Name = "Maximum points per trigger",
@@ -131,13 +138,6 @@ namespace GRA
                 {
                     Name = "Low point threshold for triggers",
                     Info = "Triggers activated with this many points or fewer are considered to be low point activated.",
-                    Category = typeof(SiteSettingKey.Triggers).Name,
-                    Format = SiteSettingFormat.Integer
-                },
-                [SiteSettingKey.Triggers.DisallowTriggersBelowPoints] = new SiteSettingDefinition
-                {
-                    Name = "Disallow triggers below these points",
-                    Info = "Triggers cannot be created below this amount of points.",
                     Category = typeof(SiteSettingKey.Triggers).Name,
                     Format = SiteSettingFormat.Integer
                 },

--- a/src/GRA/SiteSettingKey.cs
+++ b/src/GRA/SiteSettingKey.cs
@@ -84,6 +84,7 @@
     public static class Triggers
     {
         public static readonly string MaxPointsPerTrigger = "Triggers.MaxPointsPerTrigger";
+        public static readonly string LowPointThreshold = "Triggers.LowPointThreshold";
     }
 
     public static class Users

--- a/src/GRA/SiteSettingKey.cs
+++ b/src/GRA/SiteSettingKey.cs
@@ -85,6 +85,7 @@
     {
         public static readonly string MaxPointsPerTrigger = "Triggers.MaxPointsPerTrigger";
         public static readonly string LowPointThreshold = "Triggers.LowPointThreshold";
+        public static readonly string DisallowTriggersBelowPoints = "Triggers.DisallowTriggersBelowPoints";
     }
 
     public static class Users


### PR DESCRIPTION
1. Add a system setting in the Triggers area that allows for the input of a low point threshold.
    - Default value is 0
2. Add a tab on the triggers nav pills for the Low Points option
    -Queries for all the Triggers that have point values lower than the low point threshold
    -View shows every trigger that meets the query and is activated by points, not a secret code.