### PR TITLE
Update logic for item reorders

### DIFF
--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.5.1.35</FileVersion>
+    <FileVersion>4.5.1.36</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
Item reorders are solely triggered per code when a vendor invoice is imported showing an order date that is after the ship date stored in the database. Prior logic which cleared damaged/missing flags when an import came in containing a code that had been marked damaged/missing has been removed.