### PR TITLE
Add safety property for custom dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - System setting to show "only available at" next to prizes
 - Validation of aria-describedby attributes when using data validation
 - JavaScript fix to support improved accessibility for TomSelect
+- Color contrast calculations to ensure accessibility compliance
 
 ## Changed
 
@@ -58,6 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Single program not being selected when adding household members in Mission Control
 - Issue with delay upon each email send
 - Program editing ViewModel properties not being set after ModelState error
+- Avatar paths generated on-the-fly rather than stored in the database
 
 ## [4.6.0] 2024-10-09
 

--- a/src/GRA.Domain.Model/AvatarElement.cs
+++ b/src/GRA.Domain.Model/AvatarElement.cs
@@ -15,8 +15,15 @@ namespace GRA.Domain.Model
         [Required]
         public int AvatarItemId { get; set; }
 
-        public string FilenameLink { get; set; }
+        public string Filename
+        {
+            get
+            {
+                return FilenameLink;
+            }
+        }
 
+        public string FilenameLink { get; set; }
         public int LayerId { get; set; }
 
         public int LayerPosition { get; set; }

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.6.1.147</FileVersion>
+    <FileVersion>4.6.1.148</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
- The name of a property has changed on the dashboard, this adds an alias so customized dashboards won't cause an error.