### PR TITLE
Fix display of trigger attachments on edit screen

### DIFF
--- a/src/GRA.Controllers/MissionControl/TriggersController.cs
+++ b/src/GRA.Controllers/MissionControl/TriggersController.cs
@@ -456,7 +456,6 @@ namespace GRA.Controllers.MissionControl
             var viewModel = new TriggersDetailViewModel
             {
                 Action = "Edit",
-                AwardsAttachment = !string.IsNullOrWhiteSpace(trigger.AwardAttachmentFilename),
                 AwardsMail = !string.IsNullOrWhiteSpace(trigger.AwardMailSubject),
                 AwardsPrize = !string.IsNullOrWhiteSpace(trigger.AwardPrizeName),
                 BadgeAltText = badge.AltText,
@@ -534,6 +533,8 @@ namespace GRA.Controllers.MissionControl
             {
                 viewModel.Trigger.AwardAttachmentFilename
                     = _pathResolver.ResolveContentPath(attachment.FileName);
+                viewModel.AwardsAttachment 
+                    = !string.IsNullOrWhiteSpace(trigger.AwardAttachmentFilename);
             }
             if (UserHasPermission(Permission.ManageEvents))
             {

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -8,7 +8,7 @@
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2017 Maricopa County Library District</Copyright>
     <Description>The Great Reading Adventure is an open-source tool for managing dynamic library reading programs.</Description>
-    <FileVersion>4.6.1.148</FileVersion>
+    <FileVersion>4.6.1.149</FileVersion>
     <OutputType>Exe</OutputType>
     <PackageId>GRA.Web</PackageId>
     <PackageLicenseUrl>https://github.com/mcld/greatreadingadventure/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
Fix display of attachments in the trigger edit screen in Mission Control.